### PR TITLE
part 2 remove lines using 0

### DIFF
--- a/content/tutorials/tcod/2019/part-2.md
+++ b/content/tutorials/tcod/2019/part-2.md
@@ -128,15 +128,10 @@ Lastly, update the drawing functions to use the new player object:
 -       libtcod.console_put_char(con, player_x, player_y, '@', libtcod.BKGND_NONE)
 +       libtcod.console_put_char(con, player.x, player.y, '@', libtcod.BKGND_NONE)
         libtcod.console_blit(con, 0, 0, screen_width, screen_height, 0, 0, 0)
-        libtcod.console_set_default_foreground(0, libtcod.white)
--       libtcod.console_put_char(0, player_x, player_y, '@', libtcod.BKGND_NONE)
-+       libtcod.console_put_char(0, player.x, player.y, '@', libtcod.BKGND_NONE)
         libtcod.console_flush()
 
 -       libtcod.console_put_char(con, player_x, player_y, ' ', libtcod.BKGND_NONE)
--       libtcod.console_put_char(0, player_x, player_y, ' ', libtcod.BKGND_NONE)
 +       libtcod.console_put_char(con, player.x, player.y, ' ', libtcod.BKGND_NONE)
-+       libtcod.console_put_char(0, player.x, player.y, ' ', libtcod.BKGND_NONE)
 
         action = handle_keys(key)
 
@@ -150,15 +145,10 @@ Lastly, update the drawing functions to use the new player object:
         <span class="crossed-out-text">libtcod.console_put_char(con, player_x, player_y, '@', libtcod.BKGND_NONE)</span>
         <span class="new-text">libtcod.console_put_char(con, player.x, player.y, '@', libtcod.BKGND_NONE)</span>
         libtcod.console_blit(con, 0, 0, screen_width, screen_height, 0, 0, 0)
-        libtcod.console_set_default_foreground(0, libtcod.white)
-        <span class="crossed-out-text">libtcod.console_put_char(0, player_x, player_y, '@', libtcod.BKGND_NONE)</span>
-        <span class="new-text">libtcod.console_put_char(0, player.x, player.y, '@', libtcod.BKGND_NONE)</span>
         libtcod.console_flush()
 
         <span class="crossed-out-text">libtcod.console_put_char(con, player_x, player_y, ' ', libtcod.BKGND_NONE)</span>
-        <span class="crossed-out-text">libtcod.console_put_char(0, player_x, player_y, ' ', libtcod.BKGND_NONE)</span>
         <span class="new-text">libtcod.console_put_char(con, player.x, player.y, ' ', libtcod.BKGND_NONE)</span>
-        <span class="new-text">libtcod.console_put_char(0, player.x, player.y, ' ', libtcod.BKGND_NONE)</span>
 
         action = handle_keys(key)
     </pre>


### PR DESCRIPTION
The lines using `0` were removed in the last code sample of part 1 during the change to using `con` for console stuff.
They seem to have been accidentally left behind in the code sample switching from `player_x`, `player_y` to `player.x`, `player.y` but never appear again.