### PR TITLE
Update Deprecated FOV Map Code

### DIFF
--- a/content/tutorials/tcod/part-4.md
+++ b/content/tutorials/tcod/part-4.md
@@ -113,8 +113,8 @@ def initialize_fov(game_map):
 
     for y in range(game_map.height):
         for x in range(game_map.width):
-            libtcod.map_set_properties(fov_map, x, y, not game_map.tiles[x][y].block_sight,
-                                       not game_map.tiles[x][y].blocked)
+            fov_map.transparent[y,x] = not game_map.tiles[x][y].block_sight
+            fov_map.walkable[y,x] = not game_map.tiles[x][y].blocked
 
     return fov_map
 {{</ highlight >}}


### PR DESCRIPTION
map_set_properties is deprecated; changed code to use the transparent and walkable arrays of the Map object. [Documentation from tcod ReadTheDocs here.](https://python-tcod.readthedocs.io/en/latest/_modules/tcod/libtcodpy.html?highlight=map_set_properties)