### PR TITLE
Delete 'install shelve with pip' instruction

### DIFF
--- a/content/tutorials/tcod/part-10.md
+++ b/content/tutorials/tcod/part-10.md
@@ -575,8 +575,7 @@ library; specifically: `shelve`. This library allows you to save and
 load complex Python objects, without needing to write custom
 serializers.
 
-Install `shelve` in your Python installation (pip is the best way).
-Then, create a new file in `loader_functions`, called `data_loaders.py`.
+Create a new file in `loader_functions`, called `data_loaders.py`.
 We'll start by writing our save function.
 
 {{< highlight py3 >}}


### PR DESCRIPTION
shelve appears to be included in the main python library now.