### PR TITLE
Update part-7.md

### DIFF
--- a/content/tutorials/tcod/v2/part-7.md
+++ b/content/tutorials/tcod/v2/part-7.md
@@ -51,7 +51,7 @@ def render_bar(
 ) -> None:
     bar_width = int(float(current_value) / maximum_value * total_width)
 
-    console.draw_rect(x=0, y=45, width=20, height=1, ch=1, bg=color.bar_empty)
+    console.draw_rect(x=0, y=45, width=total_width, height=1, ch=1, bg=color.bar_empty)
 
     if bar_width > 0:
         console.draw_rect(


### PR DESCRIPTION
I'm not doing the tutorial in Python so apologies if I've misread, but I believe the render_bar implementation works by coincidence currently. You're using a hardcoded width value of 20, and then calling it with 20 later, where it should refer to the argument.