### PR TITLE
Fix some typos

### DIFF
--- a/content/tutorials/tcod/v2/part-10.md
+++ b/content/tutorials/tcod/v2/part-10.md
@@ -1734,7 +1734,7 @@ class GameOverEventHandler(EventHandler):
 
 We use the `os` module to find the save file, and if it exists, we remove it. We then raise `QuitWithoutSaving`, so that the game won't be saved on exiting. Now when the player meets his or her tragic end (it's a roguelike, it's inevitable!), the save file will be deleted.
 
-Last thing before we wrap up: We're creating the `.sav` files to represent our saved games, but we don't want to include these in out Git repository, since that should be reserved for just the code. The fix for this is to add this to our `.gitignore` file:
+Last thing before we wrap up: We're creating the `.sav` files to represent our saved games, but we don't want to include these in our Git repository, since that should be reserved for just the code. The fix for this is to add this to our `.gitignore` file:
 
 {{< codetab >}}
 {{< diff-tab >}}

--- a/content/tutorials/tcod/v2/part-11.md
+++ b/content/tutorials/tcod/v2/part-11.md
@@ -391,7 +391,7 @@ import input_handlers
 {{</ original-tab >}}
 {{</ codetab >}}
 
-Now, instead of calling `generate_dungeon` directly, we create a new `GameWorld` and allow it to call its `generate_floor` method. While this doesn't change anything for the first floor that's created, it will allows us to more easily create new floors on the fly.
+Now, instead of calling `generate_dungeon` directly, we create a new `GameWorld` and allow it to call its `generate_floor` method. While this doesn't change anything for the first floor that's created, it will allow us to more easily create new floors on the fly.
 
 In order to actually take the stairs, we'll need to add an action and a way for the player to trigger it. Adding the action is pretty simple. Add the following to `actions.py`:
 

--- a/content/tutorials/tcod/v2/part-13.md
+++ b/content/tutorials/tcod/v2/part-13.md
@@ -476,7 +476,7 @@ What's with the `add_message` part? Normally, we'll want to add a message to the
             self.equip_to_slot(slot, equippable_item, add_message)
 ```
 
-Finally, we have `toggle_equip`, which is the method that will actually get called when the player selects an equippable item. If checks the equipment's type (to know which slot to put it in), and then check to see if the same item is already equipped to that slot. If it is, the player presumably wants to remove it. If not, the player wants to equip it.
+Finally, we have `toggle_equip`, which is the method that will actually get called when the player selects an equippable item. It checks the equipment's type (to know which slot to put it in), and then checks to see if the same item is already equipped to that slot. If it is, the player presumably wants to remove it. If not, the player wants to equip it.
 
 To sum up, this component holds references to equippable entities, calculates the bonuses the player gets from them (which will get added to the player's power and defense values), and gives a way to equip or remove the items.
 


### PR DESCRIPTION
Thanks a lot for the tutorial :) the least I can do is report some typos I found ;) Cheers

PS: the fix of 'equppable' to 'equippable' is not represented at the website. It still reads 'equppable' there