### PR TITLE
Updated v2 tutorial for using tcod 21.2.0, numpy 2.x and modern python

### DIFF
--- a/content/tutorials/tcod/v2/part-0.md
+++ b/content/tutorials/tcod/v2/part-0.md
@@ -19,9 +19,10 @@ paragraph if you're feeling bold\!
 
 #### Installation
 
-To do this tutorial, you'll need Python version 3.7 or higher. The
-latest version of Python is recommended (currently 3.8 as of June
-2020). **Note: Python 2 is not compatible.**
+To do this tutorial, you'll need Python 3.11 or higher. This updated
+version of the tutorial has been reviewed with **Python 3.14.4**,
+**tcod 21.2.0**, and **numpy 2.4.2** on **April 21, 2026**.
+**Note: Python 2 is not compatible.**
 
 [Download Python here](https://www.python.org/downloads/).
 
@@ -34,28 +35,36 @@ here.](https://python-tcod.readthedocs.io/en/latest/installation.html)
 While you can certainly install TCOD and complete this tutorial without
 it, I'd highly recommend using a virtual environment. [Documentation on
 how to do that can be found
-here.](https://docs.python.org/3/library/venv.html)
+here.](https://docs.python.org/3/library/venv.html) A typical setup
+looks like this:
+
+{{< highlight text >}}
+python -m venv .venv
+{{</ highlight >}}
+
+Activate the environment however your shell expects, and then run the
+remaining commands from that environment.
 
 Additionally, if you are going to use a virtual environment, you may want to take the time to set up a `requirements.txt` file. This will allow you to track your project dependencies if you add any in the future, and more easily install them if you need to (for example, if you pull from a remote git repository).
 
 You can set up your `requirements.txt` file in the same directory that you plan on working in for the project. Create the file `requirements.txt` and put the following in it:
 
 {{< highlight text >}}
-tcod>=11.13
-numpy>=1.18
+tcod>=21.2,<22
+numpy>=2.4,<3
 {{</ highlight >}}
 
 Once that's done, with your virtual environment activated, type the following command:
 
-`pip install -r requirements.txt`
+`python -m pip install -r requirements.txt`
 
 This should install the TCOD library, along with its dependency, numpy.
 
-Depending on your computer, you might also need to install SDL2.
-Check the instructions for installing it based on your operating system.
-For example, Ubuntu can install it with the following command:
+Depending on your operating system, you may also need platform-specific
+build dependencies. For example, on Debian-based Linux distributions,
+the current python-tcod installation guide recommends:
 
-`sudo apt-get install libsdl2-dev`
+`sudo apt install build-essential python3-dev python3-pip python3-numpy libsdl2-dev libffi-dev`
 
 #### Editors
 
@@ -75,10 +84,12 @@ tutorial) called `main.py`, and enter the following text into it:
 
 ```py3
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import tcod
 
 
-def main():
+def main() -> None:
     print("Hello World!")
 
 
@@ -91,10 +102,9 @@ possible):
 
 `python main.py`
 
-If you're not using `virtualenv`, the command will probably look like
-this:
-
-`python3 main.py`
+On some systems, the command may be `python3 main.py` instead. If you're
+using a virtual environment, make sure it is activated before running
+the script.
 
 You should see "Hello World\!" printed out to the terminal. If you
 receive an error, there is probably an issue with either your Python or

--- a/content/tutorials/tcod/v2/part-1.md
+++ b/content/tutorials/tcod/v2/part-1.md
@@ -10,16 +10,18 @@ Welcome to part 1 of this tutorial! This series will help you create your very f
 This tutorial is largely based off the [one found on Roguebasin](http://www.roguebasin.com/index.php?title=Complete_Roguelike_Tutorial,_using_python%2Blibtcod). Many of the design decisions were mainly to keep this tutorial in lockstep
 with that one (at least in terms of chapter composition and general direction). This tutorial would not have been possible without the guidance of those who wrote that tutorial, along with all the wonderful contributors to tcod and python-tcod over the years.
 
-This part assumes that you have either checked [Part 0](/tutorials/tcod/part-0) and are already set up and ready to go. If not, be sure to check that page, and make sure that you've got Python and TCOD installed, and a file called `main.py` created in the directory that you want to work in.
+This part assumes that you have either checked [Part 0](/tutorials/tcod/v2/part-0) and are already set up and ready to go. If not, be sure to check that page, and make sure that you've got Python and TCOD installed, and a file called `main.py` created in the directory that you want to work in.
 
 Assuming that you've done all that, let's get started. Modify (or create, if you haven't already) the file `main.py` to look like this:
 
 {{< highlight py3 >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import tcod
 
 
-def main():
+def main() -> None:
     print("Hello World!")
 
 
@@ -27,9 +29,9 @@ if __name__ == "__main__":
     main()
 {{</ highlight >}}
 
-You can run the program like any other Python program, but for those who are brand new, you do that by typing `python main.py` in the terminal. If you have both Python 2 and 3 installed on your machine, you might have to use `python3 main.py` to run (it depends on your default python, and whether you're using a virtualenv or not).
+You can run the program like any other Python program, but for those who are brand new, you do that by typing `python main.py` in the terminal. On some systems, you might have to use `python3 main.py` instead, depending on how Python is installed and whether you're using a virtual environment.
 
-Alternatively, because of the first line, `#!usr/bin/env python`, you can run the program by typing `./main.py`, assuming you've either activated your virtual environment, or installed tcod on your base Python installation. This line is called a "shebang".
+Alternatively, because of the first line, `#!/usr/bin/env python3`, you can run the program by typing `./main.py`, assuming you've either activated your virtual environment, or installed tcod on your base Python installation. This line is called a "shebang".
 
 Okay, not the most exciting program in the world, I admit, but we've already got our first major difference from the other tutorial. Namely, this funky looking thing here:
 
@@ -46,6 +48,10 @@ Modify `main.py` to look like this:
 
 {{< highlight py3 >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 
@@ -54,25 +60,29 @@ def main() -> None:
     screen_height = 50
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        console = tcod.console.Console(screen_width, screen_height, order="F")
         while True:
-            root_console.print(x=1, y=1, string="@")
+            console.print(x=1, y=1, text="@")
 
-            context.present(root_console)
+            context.present(console)
 
             for event in tcod.event.wait():
-                if event.type == "QUIT":
-                    raise SystemExit()
+                match event:
+                    case tcod.event.Quit():
+                        raise SystemExit()
 
 
 if __name__ == "__main__":
@@ -94,26 +104,33 @@ Eventually, we'll load these values from a JSON file rather than hard coding the
 
 {{< highlight py3 >}}
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 {{</ highlight >}}
 
-Here, we're telling tcod which font to use. The `"dejavu10x10_gs_tc.png"` bit is the actual file we're reading from (this should exist in your project folder).
+Here, we're telling tcod which font to use. `Path(__file__).with_name("dejavu10x10_gs_tc.png")` points to the image file sitting next to `main.py`, which is a little more robust than relying on the terminal's current working directory.
+
+> **Updated from the original:** The original tutorial passed `"dejavu10x10_gs_tc.png"` as a plain string, which requires the script to be launched from the project folder. `Path(__file__).with_name(...)` resolves the path relative to the script itself, so it works regardless of the working directory.
 
 {{< highlight py3 >}}
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
-        tileset=tileset
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
+        tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
 {{</ highlight >}}
 
-This part is what actually creates the screen. We're giving it the `screen_width` and `screen_height` values from before (80 and 50, respectively), along with a title (change this if you've already got your game's name figured out). `tileset` uses the tileset we defined earlier. and `vsync` will either enable or disable vsync, which shouldn't matter too much in our case.
+This part is what actually creates the screen. We're giving it the `screen_width` and `screen_height` values from before (80 and 50, respectively), along with a title (change this if you've already got your game's name figured out). `tileset` uses the tileset we defined earlier, and `vsync` will either enable or disable vsync, which shouldn't matter too much in our case.
+
+Older versions of tcod often used `tcod.context.new_terminal`, but `tcod.context.new` is the modern API and is what the current documentation recommends.
 
 {{< highlight py3 >}}
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        console = tcod.console.Console(screen_width, screen_height, order="F")
 {{</ highlight >}}
 
 This creates our "console" which is what we'll be drawing to. We also set this console's width and height to the same as our new terminal. The "order" argument affects the order of our x and y variables in numpy (an underlying library that tcod uses). By default, numpy accesses 2D arrays in [y, x] order, which is fairly unintuitive. By setting `order="F"`, we can change this to be [x, y] instead. This will make more sense once we start drawing the map.
@@ -125,24 +142,25 @@ This creates our "console" which is what we'll be drawing to. We also set this c
 This is what's called our 'game loop'. Basically, this is a loop that won't ever end, until we close the screen. Every game has some sort of game loop or another.
 
 {{< highlight py3 >}}
-            root_console.print(x=1, y=1, string="@")
+            console.print(x=1, y=1, text="@")
 {{</ highlight >}}
 
-This line is what tells the program to actually put the "@" symbol on the screen in its proper place. We're telling the `root_console` we created to `print` the "@" symbol at the given x and y coordinates. Try changing the x and y values and see what happens, if you feel so inclined.
+This line is what tells the program to actually put the "@" symbol on the screen in its proper place. We're telling the `console` we created to `print` the "@" symbol at the given x and y coordinates. Try changing the x and y values and see what happens, if you feel so inclined.
 
 {{< highlight py3 >}}
-            context.present(root_console)
+            context.present(console)
 {{</ highlight >}}
 
 Without this line, nothing would actually print out on the screen. This is because `context.present` is what actually updates the screen with what we've told it to display so far.
 
 {{< highlight py3 >}}
             for event in tcod.event.wait():
-                if event.type == "QUIT":
-                    raise SystemExit()
+                match event:
+                    case tcod.event.Quit():
+                        raise SystemExit()
 {{</ highlight >}}
 
-This part gives us a way to gracefully exit (i.e. not crashing) the program by hitting the `X` button in the console's window. The line `for event in tcod.event.wait()` will wait for some sort of input from the user (mouse clicks, keyboard strokes, etc.) and loop through each event that happened. `SystemExit()` tells Python to quit the current running program.
+This part gives us a way to gracefully exit (i.e. not crashing) the program by hitting the `X` button in the console's window. The line `for event in tcod.event.wait()` will wait for some sort of input from the user (mouse clicks, keyboard strokes, etc.) and loop through each event that happened. The `match` statement is a clean way to handle tcod's event types with modern Python. `SystemExit()` tells Python to quit the current running program.
 
 Alright, our "@" symbol is successfully displayed on the screen, but we can't rest just yet. We still need to get it moving around\!
 
@@ -154,11 +172,14 @@ We need to keep track of the player's position at all times. Since this is a 2D 
     ...
     screen_height = 50
 +
-+   player_x = int(screen_width / 2)
-+   player_y = int(screen_height / 2)
++   player_x = screen_width // 2
++   player_y = screen_height // 2
 +
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
     ...
 {{</ highlight >}}
@@ -167,11 +188,14 @@ We need to keep track of the player's position at all times. Since this is a 2D 
 <pre>    ...
     screen_height = 50
     <span class="new-text">
-    player_x = int(screen_width / 2)
-    player_y = int(screen_height / 2)
+    player_x = screen_width // 2
+    player_y = screen_height // 2
     </span>
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
     ...</pre>
 {{</ original-tab >}}
@@ -179,10 +203,7 @@ We need to keep track of the player's position at all times. Since this is a 2D 
 
 *Note: Ellipses denote omitted parts of the code. I'll include lines around the code to be inserted so that you'll know exactly where to put new pieces of code, but I won't be showing the entire file every time. The green lines denote code that you should be adding.*
 
-We're placing the player right in the middle of the screen. What's with the `int()` function though? Well, Python 3 doesn't automatically
-truncate division like Python 2 does, so we have to cast the division result (a float) to an integer. If we don't, tcod will give an error.
-
-*Note: It's been pointed out that you could divide with `//` instead of `/` and achieve the same effect. This is true, except in cases where, for whatever reason, one of the numbers given is a decimal. For example, `screen_width // 2.0` will give an error. That shouldn't happen in this case, but wrapping the function in `int()` gives us certainty that this won't ever happen.*
+We're placing the player right in the middle of the screen. `//` is Python's integer division operator, which gives us an integer result right away without going through a floating-point number first.
 
 We also have to modify the command to put the '@' symbol to use these new coordinates.
 
@@ -191,20 +212,20 @@ We also have to modify the command to put the '@' symbol to use these new coordi
 {{< highlight diff >}}
         ...
         while True:
--           root_console.print(x=1, y=1, string="@")
-+           root_console.print(x=player_x, y=player_y, string="@")
+-           console.print(x=1, y=1, text="@")
++           console.print(x=player_x, y=player_y, text="@")
 
-            context.present(root_console)
+            context.present(console)
             ...
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>        ...
         while True:
-            <span class="crossed-out-text">root_console.print(x=1, y=1, string="@")</span>
-            <span class="new-text">root_console.print(x=player_x, y=player_y, string="@")</span>
+            <span class="crossed-out-text">console.print(x=1, y=1, text="@")</span>
+            <span class="new-text">console.print(x=player_x, y=player_y, text="@")</span>
 
-            context.present(root_console)
+            context.present(console)
             ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -228,6 +249,9 @@ To handle the keyboard inputs and the actions associated with them, let's actual
 Create two new Python files in your project's directory, one called `input_handlers.py`, and the other called `actions.py`. Let's fill out `actions.py` first:
 
 {{< highlight py3 >}}
+from __future__ import annotations
+
+
 class Action:
     pass
 
@@ -237,9 +261,7 @@ class EscapeAction(Action):
 
 
 class MovementAction(Action):
-    def __init__(self, dx: int, dy: int):
-        super().__init__()
-
+    def __init__(self, dx: int, dy: int) -> None:
         self.dx = dx
         self.dy = dy
 {{</ highlight >}}
@@ -253,32 +275,41 @@ There might be instances where we need to know more than just the "type" of acti
 That's all we need to do in `actions.py` right now. Let's fill out `input_handlers.py`, which will use the `Action` class and subclasses we just created:
 
 {{< highlight py3 >}}
-from typing import Optional
+from __future__ import annotations
 
 import tcod.event
 
 from actions import Action, EscapeAction, MovementAction
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
-    def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
+class EventHandler:
+    def dispatch(self, event: tcod.event.Event) -> Action | None:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
+
+    def ev_quit(self, event: tcod.event.Quit) -> Action | None:
         raise SystemExit()
 
-    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
-        action: Optional[Action] = None
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Action | None:
+        action: Action | None = None
 
         key = event.sym
 
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
             action = MovementAction(dx=0, dy=-1)
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
             action = MovementAction(dx=0, dy=1)
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
             action = MovementAction(dx=-1, dy=0)
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
             action = MovementAction(dx=1, dy=0)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction()
 
         # No valid key was pressed
@@ -289,10 +320,10 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 Let's go over what we've added.
 
 {{< highlight py3 >}}
-from typing import Optional
+        action: Action | None = None
 {{</ highlight >}}
 
-This is part of Python's type hinting system (which you don't have to include in your project). `Optional` denotes something that could be set to `None`.
+This is part of Python's type hinting system (which you don't have to include in your project). `Action | None` denotes something that can hold either an `Action` or `None`.
 
 {{< highlight py3 >}}
 import tcod.event
@@ -305,26 +336,32 @@ We're importing `tcod.event` so that we can use tcod's event system. We don't ne
 The next line imports the `Action` class and its subclasses that we just created.
 
 {{< highlight py3 >}}
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
 {{</ highlight >}}
 
-We're creating a class called `EventHandler`, which is a subclass of tcod's `EventDispatch` class. `EventDispatch` is a class that allows us to send an event to its proper method based on what type of event it is. Let's take a look at the methods we're creating for `EventHandler` to see a few examples of this.
+We're creating a class called `EventHandler`. Older tcod examples often subclassed `EventDispatch`, but that API is deprecated in recent versions. We'll keep a small handler class of our own, and route events through its `dispatch` method instead.
 
 {{< highlight py3 >}}
-    def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
+    def dispatch(self, event: tcod.event.Event) -> Action | None:
+{{</ highlight >}}
+
+`dispatch` takes a tcod event and sends it to the method that should handle it. If the event is a quit event, it goes to `ev_quit`. If it's a key press, it goes to `ev_keydown`. Any other event returns `None` for now.
+
+{{< highlight py3 >}}
+    def ev_quit(self, event: tcod.event.Quit) -> Action | None:
         raise SystemExit()
 {{</ highlight >}}
 
-Here's an example of us using a method of `EventDispatch`: `ev_quit` is a method defined in `EventDispatch`, which we're overriding in `EventHandler`. `ev_quit` is called when we receive a "quit" event, which happens when we click the "X" in the window of the program. In that case, we want to quit the program, so we raise `SystemExit()` to do so.
+`ev_quit` is called when we receive a "quit" event, which happens when we click the "X" in the window of the program. In that case, we want to quit the program, so we raise `SystemExit()` to do so.
 
 {{< highlight py3 >}}
-    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Action | None:
 {{</ highlight >}}
 
 This method will receive key press events, and return either an `Action` subclass, or `None`, if no valid key was pressed.
 
 {{< highlight py3 >}}
-        action: Optional[Action] = None
+        action: Action | None = None
 
         key = event.sym
 {{</ highlight >}}
@@ -336,14 +373,14 @@ This method will receive key press events, and return either an `Action` subclas
 From there, we go down a list of possible keys pressed. For example:
 
 {{< highlight py3 >}}
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
             action = MovementAction(dx=0, dy=-1)
 {{</ highlight >}}
 
 In this case, the user pressed the up-arrow key, so we're creating a `MovementAction`. Notice that here (and in all the other cases of `MovementAction`) we provide `dx` and `dy`. These describe which direction our character will move in.
 
 {{< highlight py3 >}}
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction()
 {{</ highlight >}}
 
@@ -361,6 +398,10 @@ Let's put our new actions and input handlers to use in `main.py`. Edit `main.py`
 {{< diff-tab >}}
 {{< highlight diff >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 +from actions import EscapeAction, MovementAction
@@ -371,23 +412,23 @@ def main() -> None:
     screen_width = 80
     screen_height = 50
 
-    player_x = int(screen_width / 2)
-    player_y = int(screen_height / 2)
+    player_x = screen_width // 2
+    player_y = screen_height // 2
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
 +   event_handler = EventHandler()
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 
             ...
             for event in tcod.event.wait():
--               if event.type == "QUIT":
--                   raise SystemExit()
-
 +               action = event_handler.dispatch(event)
 
 +               if action is None:
@@ -407,6 +448,10 @@ if __name__ == "__main__":
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 <span class="new-text">from actions import EscapeAction, MovementAction
@@ -417,22 +462,23 @@ def main() -> None:
     screen_width = 80
     screen_height = 50
 
-    player_x = int(screen_width / 2)
-    player_y = int(screen_height / 2)
+    player_x = screen_width // 2
+    player_y = screen_height // 2
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     <span class="new-text">event_handler = EventHandler()</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 
             ...
             for event in tcod.event.wait():
-                <span class="crossed-out-text">if event.type == "QUIT":</span>
-                    <span class="crossed-out-text">raise SystemExit()</span>
                 <span class="new-text">
                 action = event_handler.dispatch(event)
 
@@ -471,7 +517,7 @@ We're importing the `EscapeAction` and `MovementAction` from `actions`, and `Eve
                 action = event_handler.dispatch(event)
 {{</ highlight >}}
 
-We send the `event` to our `event_handler`'s "dispatch" method, which sends the event to its proper place. In this case, a keyboard event will be sent to the `ev_keydown` method we wrote. The `Action` returned from that method is assigned to our local `action` variable.
+We send the `event` to our `event_handler`'s `dispatch` method, which routes the event to its proper place. In this case, a keyboard event will be sent to the `ev_keydown` method we wrote. The `Action` returned from that method is assigned to our local `action` variable.
 
 {{< highlight py3 >}}
                 if action is None:
@@ -511,11 +557,11 @@ Turns out, we need to "clear" the console after we've drawn it, or we'll get the
 {{< highlight diff >}}
     ...
         while True:
-            root_console.print(x=player_x, y=player_y, string="@")
+            console.print(x=player_x, y=player_y, text="@")
 
-            context.present(root_console)
+            context.present(console)
 
-+           root_console.clear()
++           console.clear()
 
             for event in tcod.event.wait():
                 ...
@@ -524,11 +570,11 @@ Turns out, we need to "clear" the console after we've drawn it, or we'll get the
 {{< original-tab >}}
 <pre>    ...
         while True:
-            root_console.print(x=player_x, y=player_y, string="@")
+            console.print(x=player_x, y=player_y, text="@")
 
-            context.present(root_console)
+            context.present(console)
 
-            <span class="new-text">root_console.clear()</span>
+            <span class="new-text">console.clear()</span>
 
             for event in tcod.event.wait():
                 ...</pre>

--- a/content/tutorials/tcod/v2/part-10.md
+++ b/content/tutorials/tcod/v2/part-10.md
@@ -75,8 +75,8 @@ import tcod
 
 ...
 CONFIRM_KEYS = {
-    tcod.event.K_RETURN,
-    tcod.event.K_KP_ENTER,
+    tcod.event.KeySym.RETURN,
+    tcod.event.KeySym.KP_ENTER,
 }
 
 
@@ -89,7 +89,7 @@ CONFIRM_KEYS = {
 +"""
 
 
-+class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
++class BaseEventHandler:
 +   def handle_events(self, event: tcod.event.Event) -> BaseEventHandler:
 +       """Handle an event and return the next active event handler."""
 +       state = self.dispatch(event)
@@ -98,10 +98,34 @@ CONFIRM_KEYS = {
 +       assert not isinstance(state, Action), f"{self!r} can not handle actions."
 +       return self
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def dispatch(self, event: tcod.event.Event) -> Optional[ActionOrHandler]:
++       match event:
++           case tcod.event.Quit():
++               return self.ev_quit(event)
++           case tcod.event.KeyDown():
++               return self.ev_keydown(event)
++           case tcod.event.MouseMotion():
++               return self.ev_mousemotion(event)
++           case tcod.event.MouseButtonDown():
++               return self.ev_mousebuttondown(event)
++           case _:
++               return None
++
++   def on_render(self, console: tcod.console.Console) -> None:
 +       raise NotImplementedError()
 
-+   def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
++   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
++       return None
++
++   def ev_mousemotion(self, event: tcod.event.MouseMotion) -> Optional[ActionOrHandler]:
++       return None
++
++   def ev_mousebuttondown(
++       self, event: tcod.event.MouseButtonDown
++   ) -> Optional[ActionOrHandler]:
++       return None
++
++   def ev_quit(self, event: tcod.event.Quit) -> Optional[ActionOrHandler]:
 +       raise SystemExit()
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -116,8 +140,8 @@ import tcod
 
 ...
 CONFIRM_KEYS = {
-    tcod.event.K_RETURN,
-    tcod.event.K_KP_ENTER,
+    tcod.event.KeySym.RETURN,
+    tcod.event.KeySym.KP_ENTER,
 }
 
 
@@ -130,7 +154,7 @@ MainGameEventHandler will become the active handler.
 """</span>
 
 
-<span class="new-text">class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
+<span class="new-text">class BaseEventHandler:
     def handle_events(self, event: tcod.event.Event) -> BaseEventHandler:
         """Handle an event and return the next active event handler."""
         state = self.dispatch(event)
@@ -139,10 +163,34 @@ MainGameEventHandler will become the active handler.
         assert not isinstance(state, Action), f"{self!r} can not handle actions."
         return self
 
-    def on_render(self, console: tcod.Console) -> None:
+    def dispatch(self, event: tcod.event.Event) -> Optional[ActionOrHandler]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case tcod.event.MouseMotion():
+                return self.ev_mousemotion(event)
+            case tcod.event.MouseButtonDown():
+                return self.ev_mousebuttondown(event)
+            case _:
+                return None
+
+    def on_render(self, console: tcod.console.Console) -> None:
         raise NotImplementedError()
 
-    def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
+        return None
+
+    def ev_mousemotion(self, event: tcod.event.MouseMotion) -> Optional[ActionOrHandler]:
+        return None
+
+    def ev_mousebuttondown(
+        self, event: tcod.event.MouseButtonDown
+    ) -> Optional[ActionOrHandler]:
+        return None
+
+    def ev_quit(self, event: tcod.event.Quit) -> Optional[ActionOrHandler]:
         raise SystemExit()</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -156,7 +204,7 @@ We also need to adjust `EventHandler`:
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
--class EventHandler(tcod.event.EventDispatch[Action]):
+-class EventHandler:
 +class EventHandler(BaseEventHandler):
     def __init__(self, engine: Engine):
         self.engine = engine
@@ -182,12 +230,29 @@ We also need to adjust `EventHandler`:
 -   def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
 -       raise SystemExit()
 
-    def on_render(self, console: tcod.Console) -> None:
+-   def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+-       match event:
+-           case tcod.event.Quit():
+-               return self.ev_quit(event)
+-           case tcod.event.MouseMotion():
+-               self.ev_mousemotion(event)
+-               return None
+-           case tcod.event.MouseButtonDown():
+-               return self.ev_mousebuttondown(event)
+-           case tcod.event.KeyDown():
+-               return self.ev_keydown(event)
+-           case _:
+-               return None
+
+-   def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
+-       return None
+
+    def on_render(self, console: tcod.console.Console) -> None:
         self.engine.render(console)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre><span class="crossed-out-text">class EventHandler(tcod.event.EventDispatch[Action]):</span>
+<pre><span class="crossed-out-text">class EventHandler:</span>
 <span class="new-text">class EventHandler(BaseEventHandler):</span>
     def __init__(self, engine: Engine):
         self.engine = engine
@@ -213,12 +278,31 @@ We also need to adjust `EventHandler`:
     <span class="crossed-out-text">def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:</span>
         <span class="crossed-out-text">raise SystemExit()</span>
 
-    def on_render(self, console: tcod.Console) -> None:
+    <span class="crossed-out-text">def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.MouseMotion():
+                self.ev_mousemotion(event)
+                return None
+            case tcod.event.MouseButtonDown():
+                return self.ev_mousebuttondown(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None</span>
+
+    <span class="crossed-out-text">def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
+        return None</span>
+
+    def on_render(self, console: tcod.console.Console) -> None:
         self.engine.render(console)</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
 
 The `handle_events` method of `EventHandler` is similar to `BaseEventHandler`, except it includes logic to handle actions as well. It also contains the logic for changing our handler to a game over if the player is dead.
+
+> **Updated from the original:** `dispatch` and `ev_mousebuttondown` are removed from `EventHandler` here because `BaseEventHandler` now provides them. Keeping both would leave `EventHandler.dispatch` silently overriding `BaseEventHandler.dispatch` with identical logic — redundant dead code. After this step, all event routing for `EventHandler` and its subclasses flows through `BaseEventHandler.dispatch`.
 
 To adjust our existing handlers, we'll need to continue editing `input_handlers`. This next code section is quite long, but the idea is consistent throughout: We want to modify our return types to return `Optional[ActionOrHandler]` instead of `Optional[Action]`, and instead of setting `self.engine.event_handler` to change the handler, we'll return the handler instead.
 
@@ -239,12 +323,12 @@ class AskUserEventHandler(EventHandler):
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
         """By default any key exits this input handler."""
         if event.sym in {  # Ignore modifier keys.
-            tcod.event.K_LSHIFT,
-            tcod.event.K_RSHIFT,
-            tcod.event.K_LCTRL,
-            tcod.event.K_RCTRL,
-            tcod.event.K_LALT,
-            tcod.event.K_RALT,
+            tcod.event.KeySym.LSHIFT,
+            tcod.event.KeySym.RSHIFT,
+            tcod.event.KeySym.LCTRL,
+            tcod.event.KeySym.RCTRL,
+            tcod.event.KeySym.LALT,
+            tcod.event.KeySym.RALT,
         }:
             return None
         return self.on_exit()
@@ -274,9 +358,9 @@ class InventoryEventHandler(AskUserEventHandler):
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
         player = self.engine.player
         key = event.sym
-        index = key - tcod.event.K_a
+        index = key - tcod.event.KeySym.a
 
-        if 0 <= index <= 26:
+        if 0 <= index < 26:
             try:
                 selected_item = player.inventory.items[index]
             except IndexError:
@@ -358,22 +442,22 @@ class MainGameEventHandler(EventHandler):
         elif key in WAIT_KEYS:
             action = WaitAction(player)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             raise SystemExit()
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
 -           self.engine.event_handler = HistoryViewer(self.engine)
 +           return HistoryViewer(self.engine)
 
-        elif key == tcod.event.K_g:
+        elif key == tcod.event.KeySym.g:
             action = PickupAction(player)
 
-        elif key == tcod.event.K_i:
+        elif key == tcod.event.KeySym.i:
 -           self.engine.event_handler = InventoryActivateHandler(self.engine)
 +           return InventoryActivateHandler(self.engine)
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
 -           self.engine.event_handler = InventoryDropHandler(self.engine)
 +           return InventoryDropHandler(self.engine)
-        elif key == tcod.event.K_SLASH:
+        elif key == tcod.event.KeySym.SLASH:
 -           self.engine.event_handler = LookHandler(self.engine)
 +           return LookHandler(self.engine)
 
@@ -399,9 +483,9 @@ class HistoryViewer(EventHandler):
             else:
                 # Otherwise move while staying clamped to the bounds of the history log.
                 self.cursor = max(0, min(self.cursor + adjust, self.log_length - 1))
-        elif event.sym == tcod.event.K_HOME:
+        elif event.sym == tcod.event.KeySym.HOME:
             self.cursor = 0  # Move directly to the top message.
-        elif event.sym == tcod.event.K_END:
+        elif event.sym == tcod.event.KeySym.END:
             self.cursor = self.log_length - 1  # Move directly to the last message.
         else:  # Any other key moves back to the main game state.
 -           self.engine.event_handler = MainGameEventHandler(self.engine)
@@ -424,12 +508,12 @@ class HistoryViewer(EventHandler):
     <span class="new-text">def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:</span>
         """By default any key exits this input handler."""
         if event.sym in {  # Ignore modifier keys.
-            tcod.event.K_LSHIFT,
-            tcod.event.K_RSHIFT,
-            tcod.event.K_LCTRL,
-            tcod.event.K_RCTRL,
-            tcod.event.K_LALT,
-            tcod.event.K_RALT,
+            tcod.event.KeySym.LSHIFT,
+            tcod.event.KeySym.RSHIFT,
+            tcod.event.KeySym.LCTRL,
+            tcod.event.KeySym.RCTRL,
+            tcod.event.KeySym.LALT,
+            tcod.event.KeySym.RALT,
         }:
             return None
         return self.on_exit()
@@ -459,9 +543,9 @@ class InventoryEventHandler(AskUserEventHandler):
     <span class="new-text">def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:</span>
         player = self.engine.player
         key = event.sym
-        index = key - tcod.event.K_a
+        index = key - tcod.event.KeySym.a
 
-        if 0 <= index <= 26:
+        if 0 <= index < 26:
             try:
                 selected_item = player.inventory.items[index]
             except IndexError:
@@ -543,22 +627,22 @@ class MainGameEventHandler(EventHandler):
         elif key in WAIT_KEYS:
             action = WaitAction(player)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             raise SystemExit()
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
             <span class="crossed-out-text">self.engine.event_handler = HistoryViewer(self.engine)</span>
             <span class="new-text">return HistoryViewer(self.engine)</span>
 
-        elif key == tcod.event.K_g:
+        elif key == tcod.event.KeySym.g:
             action = PickupAction(player)
 
-        elif key == tcod.event.K_i:
+        elif key == tcod.event.KeySym.i:
             <span class="crossed-out-text">self.engine.event_handler = InventoryActivateHandler(self.engine)</span>
             <span class="new-text">return InventoryActivateHandler(self.engine)</span>
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
             <span class="crossed-out-text">self.engine.event_handler = InventoryDropHandler(self.engine)</span>
             <span class="new-text">return InventoryDropHandler(self.engine)</span>
-        elif key == tcod.event.K_SLASH:
+        elif key == tcod.event.KeySym.SLASH:
             <span class="crossed-out-text">self.engine.event_handler = LookHandler(self.engine)</span>
             <span class="new-text">return LookHandler(self.engine)</span>
 
@@ -584,9 +668,9 @@ class HistoryViewer(EventHandler):
             else:
                 # Otherwise move while staying clamped to the bounds of the history log.
                 self.cursor = max(0, min(self.cursor + adjust, self.log_length - 1))
-        elif event.sym == tcod.event.K_HOME:
+        elif event.sym == tcod.event.KeySym.HOME:
             self.cursor = 0  # Move directly to the top message.
-        elif event.sym == tcod.event.K_END:
+        elif event.sym == tcod.event.KeySym.END:
             self.cursor = self.log_length - 1  # Move directly to the last message.
         else:  # Any other key moves back to the main game state.
             <span class="crossed-out-text">self.engine.event_handler = MainGameEventHandler(self.engine)</span>
@@ -811,14 +895,14 @@ def main() -> None:
 
 +   handler: input_handlers.BaseEventHandler = input_handlers.MainGameEventHandler(engine)
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         screen_width,
         screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        root_console = tcod.console.Console(screen_width, screen_height, order="F")
 -       while True:
 -           root_console.clear()
 -           engine.event_handler.on_render(console=root_console)
@@ -826,7 +910,7 @@ def main() -> None:
 
 -           try:
 -               for event in tcod.event.wait():
--                   context.convert_event(event)
+-                   event = context.convert_event(event)
 -                   engine.event_handler.handle_events(event)
 -           except Exception:  # Handle exceptions in game.
 -               traceback.print_exc()  # Print error to stderr.
@@ -840,7 +924,7 @@ def main() -> None:
 
 +               try:
 +                   for event in tcod.event.wait():
-+                       context.convert_event(event)
++                       event = context.convert_event(event)
 +                       handler = handler.handle_events(event)
 +               except Exception:  # Handle exceptions in game.
 +                   traceback.print_exc()  # Print error to stderr.
@@ -881,14 +965,14 @@ def main() -> None:
 
     <span class="new-text">handler: input_handlers.BaseEventHandler = input_handlers.MainGameEventHandler(engine)</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         screen_width,
         screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        root_console = tcod.console.Console(screen_width, screen_height, order="F")
         <span class="crossed-out-text">while True:</span>
             <span class="crossed-out-text">root_console.clear()</span>
             <span class="crossed-out-text">engine.event_handler.on_render(console=root_console)</span>
@@ -896,7 +980,7 @@ def main() -> None:
 
             <span class="crossed-out-text">try:</span>
                 <span class="crossed-out-text">for event in tcod.event.wait():</span>
-                    <span class="crossed-out-text">context.convert_event(event)</span>
+                    <span class="crossed-out-text">event = context.convert_event(event)</span>
                     <span class="crossed-out-text">engine.event_handler.handle_events(event)</span>
             <span class="crossed-out-text">except Exception:  # Handle exceptions in game.</span>
                 <span class="crossed-out-text">traceback.print_exc()  # Print error to stderr.</span>
@@ -910,7 +994,7 @@ def main() -> None:
 
                 try:
                     for event in tcod.event.wait():
-                        context.convert_event(event)
+                        event = context.convert_event(event)
                         handler = handler.handle_events(event)
                 except Exception:  # Handle exceptions in game.
                     traceback.print_exc()  # Print error to stderr.
@@ -1068,7 +1152,7 @@ def new_game() -> Engine:
 class MainMenu(input_handlers.BaseEventHandler):
     """Handle the main menu rendering and input."""
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         """Render the main menu on a background image."""
         console.draw_semigraphics(background_image, 0, 0)
 
@@ -1077,14 +1161,14 @@ class MainMenu(input_handlers.BaseEventHandler):
             console.height // 2 - 4,
             "TOMBS OF THE ANCIENT KINGS",
             fg=color.menu_title,
-            alignment=tcod.CENTER,
+            alignment=tcod.constants.CENTER,
         )
         console.print(
             console.width // 2,
             console.height - 2,
             "By (Your name here)",
             fg=color.menu_title,
-            alignment=tcod.CENTER,
+            alignment=tcod.constants.CENTER,
         )
 
         menu_width = 24
@@ -1097,19 +1181,19 @@ class MainMenu(input_handlers.BaseEventHandler):
                 text.ljust(menu_width),
                 fg=color.menu_text,
                 bg=color.black,
-                alignment=tcod.CENTER,
-                bg_blend=tcod.BKGND_ALPHA(64),
+                alignment=tcod.constants.CENTER,
+                bg_blend=tcod.libtcodpy.BKGND_ALPHA(64),
             )
 
     def ev_keydown(
         self, event: tcod.event.KeyDown
     ) -> Optional[input_handlers.BaseEventHandler]:
-        if event.sym in (tcod.event.K_q, tcod.event.K_ESCAPE):
+        if event.sym in (tcod.event.KeySym.q, tcod.event.KeySym.ESCAPE):
             raise SystemExit()
-        elif event.sym == tcod.event.K_c:
+        elif event.sym == tcod.event.KeySym.c:
             # TODO: Load the game here
             pass
-        elif event.sym == tcod.event.K_n:
+        elif event.sym == tcod.event.KeySym.n:
             return input_handlers.MainGameEventHandler(new_game())
 
         return None
@@ -1168,7 +1252,7 @@ This should all look very familiar: it's the same code we used to initialize our
 class MainMenu(input_handlers.BaseEventHandler):
     """Handle the main menu rendering and input."""
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         """Render the main menu on a background image."""
         console.draw_semigraphics(background_image, 0, 0)
 
@@ -1177,14 +1261,14 @@ class MainMenu(input_handlers.BaseEventHandler):
             console.height // 2 - 4,
             "TOMBS OF THE ANCIENT KINGS",
             fg=color.menu_title,
-            alignment=tcod.CENTER,
+            alignment=tcod.constants.CENTER,
         )
         console.print(
             console.width // 2,
             console.height - 2,
             "By (Your name here)",
             fg=color.menu_title,
-            alignment=tcod.CENTER,
+            alignment=tcod.constants.CENTER,
         )
 
         menu_width = 24
@@ -1197,19 +1281,19 @@ class MainMenu(input_handlers.BaseEventHandler):
                 text.ljust(menu_width),
                 fg=color.menu_text,
                 bg=color.black,
-                alignment=tcod.CENTER,
-                bg_blend=tcod.BKGND_ALPHA(64),
+                alignment=tcod.constants.CENTER,
+                bg_blend=tcod.libtcodpy.BKGND_ALPHA(64),
             )
 
     def ev_keydown(
         self, event: tcod.event.KeyDown
     ) -> Optional[input_handlers.BaseEventHandler]:
-        if event.sym in (tcod.event.K_q, tcod.event.K_ESCAPE):
+        if event.sym in (tcod.event.KeySym.q, tcod.event.KeySym.ESCAPE):
             raise SystemExit()
-        elif event.sym == tcod.event.K_c:
+        elif event.sym == tcod.event.KeySym.c:
             # TODO: Load the game here
             pass
-        elif event.sym == tcod.event.K_n:
+        elif event.sym == tcod.event.KeySym.n:
             return input_handlers.MainGameEventHandler(new_game())
 
         return None
@@ -1289,7 +1373,7 @@ def main() -> None:
 -   handler: input_handlers.BaseEventHandler = input_handlers.MainGameEventHandler(engine)
 +   handler: input_handlers.BaseEventHandler = setup_game.MainMenu()
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -1350,7 +1434,7 @@ def main() -> None:
     <span class="crossed-out-text">handler: input_handlers.BaseEventHandler = input_handlers.MainGameEventHandler(engine)</span>
     <span class="new-text">handler: input_handlers.BaseEventHandler = setup_game.MainMenu()</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -1494,7 +1578,7 @@ Add this class to `input_handlers.py`:
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
+class BaseEventHandler:
     ...
 
 
@@ -1505,11 +1589,11 @@ class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
 +       self.parent = parent_handler
 +       self.text = text
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def on_render(self, console: tcod.console.Console) -> None:
 +       """Render the parent and dim the result, then print the message on top."""
 +       self.parent.on_render(console)
-+       console.tiles_rgb["fg"] //= 8
-+       console.tiles_rgb["bg"] //= 8
++       console.rgb["fg"] //= 8
++       console.rgb["bg"] //= 8
 
 +       console.print(
 +           console.width // 2,
@@ -1517,7 +1601,7 @@ class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
 +           self.text,
 +           fg=color.white,
 +           bg=color.black,
-+           alignment=tcod.CENTER,
++           alignment=tcod.constants.CENTER,
 +       )
 
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[BaseEventHandler]:
@@ -1530,7 +1614,7 @@ class EventHandler(BaseEventHandler):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>class BaseEventHandler(tcod.event.EventDispatch[ActionOrHandler]):
+<pre>class BaseEventHandler:
     ...
 
 
@@ -1541,11 +1625,11 @@ class EventHandler(BaseEventHandler):
         self.parent = parent_handler
         self.text = text
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         """Render the parent and dim the result, then print the message on top."""
         self.parent.on_render(console)
-        console.tiles_rgb["fg"] //= 8
-        console.tiles_rgb["bg"] //= 8
+        console.rgb["fg"] //= 8
+        console.rgb["bg"] //= 8
 
         console.print(
             console.width // 2,
@@ -1553,7 +1637,7 @@ class EventHandler(BaseEventHandler):
             self.text,
             fg=color.white,
             bg=color.black,
-            alignment=tcod.CENTER,
+            alignment=tcod.constants.CENTER,
         )
 
     def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[BaseEventHandler]:
@@ -1603,9 +1687,9 @@ class MainMenu(input_handlers.BaseEventHandler):
     def ev_keydown(
         self, event: tcod.event.KeyDown
     ) -> Optional[input_handlers.BaseEventHandler]:
-        if event.sym in (tcod.event.K_q, tcod.event.K_ESCAPE):
+        if event.sym in (tcod.event.KeySym.q, tcod.event.KeySym.ESCAPE):
             raise SystemExit()
-        elif event.sym == tcod.event.K_c:
+        elif event.sym == tcod.event.KeySym.c:
 -           # TODO: Load the game here
 -           pass
 +           try:
@@ -1615,7 +1699,7 @@ class MainMenu(input_handlers.BaseEventHandler):
 +           except Exception as exc:
 +               traceback.print_exc()  # Print to stderr.
 +               return input_handlers.PopupMessage(self, f"Failed to load save:\n{exc}")
-        elif event.sym == tcod.event.K_n:
+        elif event.sym == tcod.event.KeySym.n:
             return input_handlers.MainGameEventHandler(new_game())
 
         return None
@@ -1652,9 +1736,9 @@ class MainMenu(input_handlers.BaseEventHandler):
     def ev_keydown(
         self, event: tcod.event.KeyDown
     ) -> Optional[input_handlers.BaseEventHandler]:
-        if event.sym in (tcod.event.K_q, tcod.event.K_ESCAPE):
+        if event.sym in (tcod.event.KeySym.q, tcod.event.KeySym.ESCAPE):
             raise SystemExit()
-        elif event.sym == tcod.event.K_c:
+        elif event.sym == tcod.event.KeySym.c:
             <span class="crossed-out-text"># TODO: Load the game here</span>
             <span class="crossed-out-text">pass</span>
             <span class="new-text">try:
@@ -1664,7 +1748,7 @@ class MainMenu(input_handlers.BaseEventHandler):
             except Exception as exc:
                 traceback.print_exc()  # Print to stderr.
                 return input_handlers.PopupMessage(self, f"Failed to load save:\n{exc}")</span>
-        elif event.sym == tcod.event.K_n:
+        elif event.sym == tcod.event.KeySym.n:
             return input_handlers.MainGameEventHandler(new_game())
 
         return None</pre>
@@ -1701,7 +1785,7 @@ class GameOverEventHandler(EventHandler):
 +       self.on_quit()
 
     def ev_keydown(self, event: tcod.event.KeyDown) -> None:
-        if event.sym == tcod.event.K_ESCAPE:
+        if event.sym == tcod.event.KeySym.ESCAPE:
 -           raise SystemExit()
 +           self.on_quit()
 {{</ highlight >}}
@@ -1726,7 +1810,7 @@ class GameOverEventHandler(EventHandler):
         self.on_quit()</span>
 
     def ev_keydown(self, event: tcod.event.KeyDown) -> None:
-        if event.sym == tcod.event.K_ESCAPE:
+        if event.sym == tcod.event.KeySym.ESCAPE:
             <span class="crossed-out-text">raise SystemExit()</span>
             <span class="new-text">self.on_quit()</span></pre>
 {{</ original-tab >}}

--- a/content/tutorials/tcod/v2/part-11.md
+++ b/content/tutorials/tcod/v2/part-11.md
@@ -460,8 +460,9 @@ class MainGameEventHandler(EventHandler):
 
         player = self.engine.player
 
-+       if key == tcod.event.K_PERIOD and modifier & (
-+           tcod.event.KMOD_LSHIFT | tcod.event.KMOD_RSHIFT
++       if key == tcod.event.KeySym.GREATER or (
++           key == tcod.event.KeySym.PERIOD
++           and modifier & (tcod.event.Modifier.LSHIFT | tcod.event.Modifier.RSHIFT)
 +       ):
 +           return actions.TakeStairsAction(player)
 
@@ -479,8 +480,9 @@ class MainGameEventHandler(EventHandler):
 
         player = self.engine.player
 
-        <span class="new-text">if key == tcod.event.K_PERIOD and modifier & (
-            tcod.event.KMOD_LSHIFT | tcod.event.KMOD_RSHIFT
+        <span class="new-text">if key == tcod.event.KeySym.GREATER or (
+            key == tcod.event.KeySym.PERIOD
+            and modifier & (tcod.event.Modifier.LSHIFT | tcod.event.Modifier.RSHIFT)
         ):
             return actions.TakeStairsAction(player)</span>
 
@@ -526,7 +528,7 @@ def render_bar(
 +   """
 +   x, y = location
 
-+   console.print(x=x, y=y, string=f"Dungeon level: {dungeon_level}")
++   console.print(x=x, y=y, text=f"Dungeon level: {dungeon_level}")
 
 
 def render_names_at_mouse_location(
@@ -559,7 +561,7 @@ def render_bar(
     """
     x, y = location
 
-    console.print(x=x, y=y, string=f"Dungeon level: {dungeon_level}")</span>
+    console.print(x=x, y=y, text=f"Dungeon level: {dungeon_level}")</span>
 
 
 def render_names_at_mouse_location(
@@ -1097,29 +1099,29 @@ class AskUserEventHandler(EventHandler):
 +           bg=(0, 0, 0),
 +       )
 
-+       console.print(x=x + 1, y=1, string="Congratulations! You level up!")
-+       console.print(x=x + 1, y=2, string="Select an attribute to increase.")
++       console.print(x=x + 1, y=1, text="Congratulations! You level up!")
++       console.print(x=x + 1, y=2, text="Select an attribute to increase.")
 
 +       console.print(
 +           x=x + 1,
 +           y=4,
-+           string=f"a) Constitution (+20 HP, from {self.engine.player.fighter.max_hp})",
++           text=f"a) Constitution (+20 HP, from {self.engine.player.fighter.max_hp})",
 +       )
 +       console.print(
 +           x=x + 1,
 +           y=5,
-+           string=f"b) Strength (+1 attack, from {self.engine.player.fighter.power})",
++           text=f"b) Strength (+1 attack, from {self.engine.player.fighter.power})",
 +       )
 +       console.print(
 +           x=x + 1,
 +           y=6,
-+           string=f"c) Agility (+1 defense, from {self.engine.player.fighter.defense})",
++           text=f"c) Agility (+1 defense, from {self.engine.player.fighter.defense})",
 +       )
 
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
 +       player = self.engine.player
 +       key = event.sym
-+       index = key - tcod.event.K_a
++       index = key - tcod.event.KeySym.a
 
 +       if 0 <= index <= 2:
 +           if index == 0:
@@ -1155,7 +1157,7 @@ class InventoryEventHandler(AskUserEventHandler):
 <span class="new-text">class LevelUpEventHandler(AskUserEventHandler):
     TITLE = "Level Up"
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         super().on_render(console)
 
         if self.engine.player.x <= 30:
@@ -1174,29 +1176,29 @@ class InventoryEventHandler(AskUserEventHandler):
             bg=(0, 0, 0),
         )
 
-        console.print(x=x + 1, y=1, string="Congratulations! You level up!")
-        console.print(x=x + 1, y=2, string="Select an attribute to increase.")
+        console.print(x=x + 1, y=1, text="Congratulations! You level up!")
+        console.print(x=x + 1, y=2, text="Select an attribute to increase.")
 
         console.print(
             x=x + 1,
             y=4,
-            string=f"a) Constitution (+20 HP, from {self.engine.player.fighter.max_hp})",
+            text=f"a) Constitution (+20 HP, from {self.engine.player.fighter.max_hp})",
         )
         console.print(
             x=x + 1,
             y=5,
-            string=f"b) Strength (+1 attack, from {self.engine.player.fighter.power})",
+            text=f"b) Strength (+1 attack, from {self.engine.player.fighter.power})",
         )
         console.print(
             x=x + 1,
             y=6,
-            string=f"c) Agility (+1 defense, from {self.engine.player.fighter.defense})",
+            text=f"c) Agility (+1 defense, from {self.engine.player.fighter.defense})",
         )
 
     def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[ActionOrHandler]:
         player = self.engine.player
         key = event.sym
-        index = key - tcod.event.K_a
+        index = key - tcod.event.KeySym.a
 
         if 0 <= index <= 2:
             if index == 0:
@@ -1290,22 +1292,22 @@ class AskUserEventHandler(EventHandler):
 +       )
 
 +       console.print(
-+           x=x + 1, y=y + 1, string=f"Level: {self.engine.player.level.current_level}"
++           x=x + 1, y=y + 1, text=f"Level: {self.engine.player.level.current_level}"
 +       )
 +       console.print(
-+           x=x + 1, y=y + 2, string=f"XP: {self.engine.player.level.current_xp}"
++           x=x + 1, y=y + 2, text=f"XP: {self.engine.player.level.current_xp}"
 +       )
 +       console.print(
 +           x=x + 1,
 +           y=y + 3,
-+           string=f"XP for next Level: {self.engine.player.level.experience_to_next_level}",
++           text=f"XP for next Level: {self.engine.player.level.experience_to_next_level}",
 +       )
 
 +       console.print(
-+           x=x + 1, y=y + 4, string=f"Attack: {self.engine.player.fighter.power}"
++           x=x + 1, y=y + 4, text=f"Attack: {self.engine.player.fighter.power}"
 +       )
 +       console.print(
-+           x=x + 1, y=y + 5, string=f"Defense: {self.engine.player.fighter.defense}"
++           x=x + 1, y=y + 5, text=f"Defense: {self.engine.player.fighter.defense}"
 +       )
 
 class LevelUpEventHandler(AskUserEventHandler):
@@ -1319,7 +1321,7 @@ class LevelUpEventHandler(AskUserEventHandler):
 <span class="new-text">class CharacterScreenEventHandler(AskUserEventHandler):
     TITLE = "Character Information"
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         super().on_render(console)
 
         if self.engine.player.x <= 30:
@@ -1343,22 +1345,22 @@ class LevelUpEventHandler(AskUserEventHandler):
         )
 
         console.print(
-            x=x + 1, y=y + 1, string=f"Level: {self.engine.player.level.current_level}"
+            x=x + 1, y=y + 1, text=f"Level: {self.engine.player.level.current_level}"
         )
         console.print(
-            x=x + 1, y=y + 2, string=f"XP: {self.engine.player.level.current_xp}"
+            x=x + 1, y=y + 2, text=f"XP: {self.engine.player.level.current_xp}"
         )
         console.print(
             x=x + 1,
             y=y + 3,
-            string=f"XP for next Level: {self.engine.player.level.experience_to_next_level}",
+            text=f"XP for next Level: {self.engine.player.level.experience_to_next_level}",
         )
 
         console.print(
-            x=x + 1, y=y + 4, string=f"Attack: {self.engine.player.fighter.power}"
+            x=x + 1, y=y + 4, text=f"Attack: {self.engine.player.fighter.power}"
         )
         console.print(
-            x=x + 1, y=y + 5, string=f"Defense: {self.engine.player.fighter.defense}"
+            x=x + 1, y=y + 5, text=f"Defense: {self.engine.player.fighter.defense}"
         )</span>
 
 class LevelUpEventHandler(AskUserEventHandler):
@@ -1373,20 +1375,20 @@ To open the screen, we'll have the player press the `c` key. Add the following t
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
             return InventoryDropHandler(self.engine)
-+       elif key == tcod.event.K_c:
++       elif key == tcod.event.KeySym.c:
 +           return CharacterScreenEventHandler(self.engine)
-        elif key == tcod.event.K_SLASH:
+        elif key == tcod.event.KeySym.SLASH:
             return LookHandler(self.engine)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>        elif key == tcod.event.K_d:
+<pre>        elif key == tcod.event.KeySym.d:
             return InventoryDropHandler(self.engine)
-        <span class="new-text">elif key == tcod.event.K_c:
+        <span class="new-text">elif key == tcod.event.KeySym.c:
             return CharacterScreenEventHandler(self.engine)</span>
-        elif key == tcod.event.K_SLASH:
+        elif key == tcod.event.KeySym.SLASH:
             return LookHandler(self.engine)</pre>
 {{</ original-tab >}}
 {{</ codetab >}}

--- a/content/tutorials/tcod/v2/part-12.md
+++ b/content/tutorials/tcod/v2/part-12.md
@@ -608,10 +608,10 @@ Putting this function to use is quite simple. In fact, it will reduce the amount
 {{< highlight diff >}}
 def place_entities(room: RectangularRoom, dungeon: GameMap, floor_number: int,) -> None:
     number_of_monsters = random.randint(
-        0, get_weight_for_floor(max_monsters_by_floor, floor_number)
+        0, get_max_value_for_floor(max_monsters_by_floor, floor_number)
     )
     number_of_items = random.randint(
-        0, get_weight_for_floor(max_items_by_floor, floor_number)
+        0, get_max_value_for_floor(max_items_by_floor, floor_number)
     )
 
 +   monsters: List[Entity] = get_entities_at_random(
@@ -655,10 +655,10 @@ def place_entities(room: RectangularRoom, dungeon: GameMap, floor_number: int,) 
 {{< original-tab >}}
 <pre>def place_entities(room: RectangularRoom, dungeon: GameMap, floor_number: int,) -> None:
     number_of_monsters = random.randint(
-        0, get_weight_for_floor(max_monsters_by_floor, floor_number)
+        0, get_max_value_for_floor(max_monsters_by_floor, floor_number)
     )
     number_of_items = random.randint(
-        0, get_weight_for_floor(max_items_by_floor, floor_number)
+        0, get_max_value_for_floor(max_items_by_floor, floor_number)
     )
 
     <span class="new-text">monsters: List[Entity] = get_entities_at_random(

--- a/content/tutorials/tcod/v2/part-13.md
+++ b/content/tutorials/tcod/v2/part-13.md
@@ -989,7 +989,7 @@ Modify `input_handlers.py` like this:
 {{< diff-tab >}}
 {{< highlight diff >}}
 class InventoryEventHandler(AskUserEventHandler):
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         ...
 
         if number_of_items_in_inventory > 0:
@@ -1033,7 +1033,7 @@ class InventoryDropHandler(InventoryEventHandler):
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>class InventoryEventHandler(AskUserEventHandler):
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         ...
 
         if number_of_items_in_inventory > 0:

--- a/content/tutorials/tcod/v2/part-2.md
+++ b/content/tutorials/tcod/v2/part-2.md
@@ -54,6 +54,10 @@ Let's put our fancy new class into action\! Modify the first part of
 {{< diff-tab >}}
 {{< highlight diff >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 from actions import EscapeAction, MovementAction
@@ -65,25 +69,32 @@ def main() -> None:
     screen_width = 80
     screen_height = 50
 
--   player_x = int(screen_width / 2)
--   player_y = int(screen_height / 2)
+-   player_x = screen_width // 2
+-   player_y = screen_height // 2
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-+   player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-+   npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
++   player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
++   npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
 +   entities = {npc, player}
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 from actions import EscapeAction, MovementAction
@@ -95,20 +106,23 @@ def main() -> None:
     screen_width = 80
     screen_height = 50
 
-    <span class="crossed-out-text">player_x = int(screen_width / 2)</span>
-    <span class="crossed-out-text">player_y = int(screen_height / 2)</span>
+    <span class="crossed-out-text">player_x = screen_width // 2</span>
+    <span class="crossed-out-text">player_y = screen_height // 2</span>
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-    <span class="new-text">player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    <span class="new-text">player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
     entities = {npc, player}</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -144,18 +158,18 @@ Lastly, update the drawing functions to use the new player object:
 {{< diff-tab >}}
 {{< highlight diff >}}
         while True:
--           root_console.print(x=player_x, y=player_y, string="@")
-+           root_console.print(x=player.x, y=player.y, string=player.char, fg=player.color)
+-           console.print(x=player_x, y=player_y, text="@")
++           console.print(x=player.x, y=player.y, text=player.char, fg=player.color)
 
-            context.present(root_console)
+            context.present(console)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>        while True:
-            <span class="crossed-out-text">root_console.print(x=player_x, y=player_y, string="@")</span>
-            <span class="new-text">root_console.print(x=player.x, y=player.y, string=player.char, fg=player.color)</span>
+            <span class="crossed-out-text">console.print(x=player_x, y=player_y, text="@")</span>
+            <span class="new-text">console.print(x=player.x, y=player.y, text=player.char, fg=player.color)</span>
 
-            context.present(root_console)</pre>
+            context.present(console)</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
 
@@ -265,6 +279,10 @@ To make use of our new `Engine` class, we'll need to modify `main.py` quite a bi
 {{< diff-tab >}}
 {{< highlight diff >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 -from actions import EscapeAction, MovementAction
@@ -278,34 +296,36 @@ def main() -> None:
     screen_height = 50
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
     entities = {npc, player}
 
 +   engine = Engine(entities=entities, event_handler=event_handler, player=player)
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        console = tcod.console.Console(screen_width, screen_height, order="F")
         while True:
--           root_console.print(x=player_x, y=player_y, string="@")
-+           engine.render(console=root_console, context=context)
+-           console.print(x=player.x, y=player.y, text=player.char, fg=player.color)
++           engine.render(console=console, context=context)
 
--           context.present(root_console)
 +           events = tcod.event.wait()
 
 +           engine.handle_events(events)
--           root_console.clear()
+-           console.clear()
 
 -           for event in tcod.event.wait():
 -               action = event_handler.dispatch(event)
@@ -327,6 +347,10 @@ if __name__ == "__main__":
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 <span class="crossed-out-text">from actions import EscapeAction, MovementAction</span>
@@ -340,34 +364,36 @@ def main() -> None:
     screen_height = 50
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
     entities = {npc, player}
 
     <span class="new-text">engine = Engine(entities=entities, event_handler=event_handler, player=player)</span>
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
     ) as context:
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        console = tcod.console.Console(screen_width, screen_height, order="F")
         while True:
-            <span class="crossed-out-text">root_console.print(x=player_x, y=player_y, string="@")</span>
-            <span class="new-text">engine.render(console=root_console, context=context)</span>
+            <span class="crossed-out-text">console.print(x=player.x, y=player.y, text=player.char, fg=player.color)</span>
+            <span class="new-text">engine.render(console=console, context=context)</span>
 
-            <span class="crossed-out-text">context.present(root_console)</span>
             <span class="new-text">events = tcod.event.wait()</span>
 
             <span class="new-text">engine.handle_events(events)</span>
-            <span class="crossed-out-text">root_console.clear()</span>
+            <span class="crossed-out-text">console.clear()</span>
 
             <span class="crossed-out-text">for event in tcod.event.wait():</span>
                 <span class="crossed-out-text">action = event_handler.dispatch(event)</span>
@@ -417,8 +443,8 @@ graphic_dt = np.dtype(
 # Tile struct used for statically defined tile data.
 tile_dt = np.dtype(
     [
-        ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("walkable", np.bool_),  # True if this tile can be walked over.
+        ("transparent", np.bool_),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
     ]
 )
@@ -467,8 +493,8 @@ We take this new data type and use it in the next bit:
 # Tile struct used for statically defined tile data.
 tile_dt = np.dtype(
     [
-        ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("walkable", np.bool_),  # True if this tile can be walked over.
+        ("transparent", np.bool_),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
     ]
 )
@@ -479,6 +505,8 @@ This is yet another `dtype`, which we'll use in the actual tile itself. It's als
 * `walkable`: A boolean that describes if the player can walk across this tile.
 * `transparent`: A boolean that describes if this tile does or does not block the field of view. Not used in this chapter, but will be in chapter 4.
 * `dark`: This uses our previously defined `dtype`, which holds the character to print, the foreground color, and the background color. Why is it called `dark`? Because later on, we'll want to differentiate between tiles that are and aren't in the field of view. `dark` will represent tiles that are not in the current field of view. Again, we'll cover that in part 4.
+
+We're using `np.bool_` here because that is the current NumPy boolean scalar type. Older code sometimes used `np.bool`, but that alias is no longer appropriate on modern NumPy releases.
 
 ```py3
 def new_tile(
@@ -569,6 +597,10 @@ With our `GameMap` class ready to go, let's modify `main.py` to make use of it. 
 {{< diff-tab >}}
 {{< highlight diff >}}
 #!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 from engine import Engine
@@ -585,13 +617,16 @@ def main() -> None:
 +   map_height = 45
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
     entities = {npc, player}
 
 +   game_map = GameMap(map_width, map_height)
@@ -599,9 +634,9 @@ def main() -> None:
 -   engine = Engine(entities=entities, event_handler=event_handler, player=player)
 +   engine = Engine(entities=entities, event_handler=event_handler, game_map=game_map, player=player)
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,
@@ -610,6 +645,10 @@ def main() -> None:
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
 import tcod
 
 from engine import Engine
@@ -626,13 +665,16 @@ def main() -> None:
     map_height = 45</span>
 
     tileset = tcod.tileset.load_tilesheet(
-        "dejavu10x10_gs_tc.png", 32, 8, tcod.tileset.CHARMAP_TCOD
+        Path(__file__).with_name("dejavu10x10_gs_tc.png"),
+        32,
+        8,
+        tcod.tileset.CHARMAP_TCOD,
     )
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
     entities = {npc, player}
 
     <span class="new-text">game_map = GameMap(map_width, map_height)</span>
@@ -640,9 +682,9 @@ def main() -> None:
     <span class="crossed-out-text">engine = Engine(entities=entities, event_handler=event_handler, player=player)</span>
     <span class="new-text">engine = Engine(entities=entities, event_handler=event_handler, game_map=game_map, player=player)</span>
 
-    with tcod.context.new_terminal(
-        screen_width,
-        screen_height,
+    with tcod.context.new(
+        columns=screen_width,
+        rows=screen_height,
         tileset=tileset,
         title="Yet Another Roguelike Tutorial",
         vsync=True,

--- a/content/tutorials/tcod/v2/part-3.md
+++ b/content/tutorials/tcod/v2/part-3.md
@@ -4,7 +4,7 @@ date: 2020-06-23
 draft: false
 ---
 
-*Note: This part of the tutorial relies on TCOD version 11.14 or higher. You might need to upgrade the library (and your requirements.txt file, if you're using one).*
+*Note: This part of the tutorial has been reviewed with tcod 21.2.0 and numpy 2.4.2. If you're following along with an older environment, upgrade your dependencies before continuing.*
 
 Remember how we created a wall in the last part? We won't need that anymore. Additionally, our dungeon generator will start by filling the entire map with "wall" tiles and "carving" out rooms, so we can modify our `GameMap` class to fill in walls instead of floors.
 
@@ -54,8 +54,8 @@ class RectangularRoom:
 
     @property
     def center(self) -> Tuple[int, int]:
-        center_x = int((self.x1 + self.x2) / 2)
-        center_y = int((self.y1 + self.y2) / 2)
+        center_x = (self.x1 + self.x2) // 2
+        center_y = (self.y1 + self.y2) // 2
 
         return center_x, center_y
 
@@ -142,7 +142,7 @@ class RectangularRoom:
         return slice(self.x1 + 1, self.x2), slice(self.y1 + 1, self.y2)
 
 
-+def generate_dungeon(map_width, map_height) -> GameMap:
++def generate_dungeon(map_width: int, map_height: int) -> GameMap:
 +   dungeon = GameMap(map_width, map_height)
 
 +   room_1 = RectangularRoom(x=20, y=15, width=10, height=15)
@@ -174,7 +174,7 @@ class RectangularRoom:
         return slice(self.x1 + 1, self.x2), slice(self.y1 + 1, self.y2)
 
 
-<span class="new-text">def generate_dungeon(map_width, map_height) -> GameMap:
+<span class="new-text">def generate_dungeon(map_width: int, map_height: int) -> GameMap:
     dungeon = GameMap(map_width, map_height)
 
     room_1 = RectangularRoom(x=20, y=15, width=10, height=15)
@@ -280,7 +280,7 @@ import tile_types
 +       yield x, y
 
 
-def generate_dungeon(map_width, map_height) -> GameMap:
+def generate_dungeon(map_width: int, map_height: int) -> GameMap:
     ...
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -320,7 +320,7 @@ import tile_types
         yield x, y</span>
 
 
-def generate_dungeon(map_width, map_height) -> GameMap:
+def generate_dungeon(map_width: int, map_height: int) -> GameMap:
     ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -422,8 +422,8 @@ class RectangularRoom:
 
     @property
     def center(self) -> Tuple[int, int]:
-        center_x = int((self.x1 + self.x2) / 2)
-        center_y = int((self.y1 + self.y2) / 2)
+        center_x = (self.x1 + self.x2) // 2
+        center_y = (self.y1 + self.y2) // 2
 
         return center_x, center_y
 
@@ -467,8 +467,8 @@ class RectangularRoom:
 
     @property
     def center(self) -> Tuple[int, int]:
-        center_x = int((self.x1 + self.x2) / 2)
-        center_y = int((self.y1 + self.y2) / 2)
+        center_x = (self.x1 + self.x2) // 2
+        center_y = (self.y1 + self.y2) // 2
 
         return center_x, center_y
 
@@ -539,7 +539,7 @@ import tile_types
 
 ...
 
--def generate_dungeon(map_width, map_height) -> GameMap:
+-def generate_dungeon(map_width: int, map_height: int) -> GameMap:
 -   dungeon = GameMap(map_width, map_height)
 
 -   room_1 = RectangularRoom(x=20, y=15, width=10, height=15)
@@ -614,7 +614,7 @@ import tile_types
 
 ...
 
-<span class="crossed-out-text">def generate_dungeon(map_width, map_height) -> GameMap:</span>
+<span class="crossed-out-text">def generate_dungeon(map_width: int, map_height: int) -> GameMap:</span>
     <span class="crossed-out-text">dungeon = GameMap(map_width, map_height)</span>
 
     <span class="crossed-out-text">room_1 = RectangularRoom(x=20, y=15, width=10, height=15)</span>

--- a/content/tutorials/tcod/v2/part-4.md
+++ b/content/tutorials/tcod/v2/part-4.md
@@ -57,8 +57,8 @@ For that, we'll want a new `graphic_dt` in the `tile_dt` type, called `light`. W
 {{< highlight diff >}}
 tile_dt = np.dtype(
     [
-        ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("walkable", np.bool_),  # True if this tile can be walked over.
+        ("transparent", np.bool_),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
 +       ("light", graphic_dt),  # Graphics for when the tile is in FOV.
     ]
@@ -99,8 +99,8 @@ wall = new_tile(
 {{< original-tab >}}
 <pre>tile_dt = np.dtype(
     [
-        ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("walkable", np.bool_),  # True if this tile can be walked over.
+        ("transparent", np.bool_),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
         <span class="new-text">("light", graphic_dt),  # Graphics for when the tile is in FOV.</span>
     ]
@@ -144,8 +144,8 @@ Let's go through the new additions.
 ```py3
 tile_dt = np.dtype(
     [
-        ("walkable", np.bool),  # True if this tile can be walked over.
-        ("transparent", np.bool),  # True if this tile doesn't block FOV.
+        ("walkable", np.bool_),  # True if this tile can be walked over.
+        ("transparent", np.bool_),  # True if this tile doesn't block FOV.
         ("dark", graphic_dt),  # Graphics for when this tile is not in FOV.
         ("light", graphic_dt),  # Graphics for when the tile is in FOV.
     ]
@@ -153,6 +153,8 @@ tile_dt = np.dtype(
 ```
 
 We're adding a new `graphic_dt` to the `tile_dt` that we use to define our tiles. `light` will hold the information about what our tile looks like when it's in the field of view.
+
+You'll also notice `np.bool_` in the dtype definition. That's the NumPy scalar type for booleans, and it's the correct choice for current NumPy versions.
 
 ```py3
 def new_tile(

--- a/content/tutorials/tcod/v2/part-5.md
+++ b/content/tutorials/tcod/v2/part-5.md
@@ -98,8 +98,8 @@ Because we've modified the definition of `Engine.__init__`, we need to modify `m
 {{< diff-tab >}}
 {{< highlight diff >}}
     ...
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
--   npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+-   npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))
 -   entities = {npc, player}
 
     game_map = generate_dungeon(
@@ -114,14 +114,14 @@ Because we've modified the definition of `Engine.__init__`, we need to modify `m
 -   engine = Engine(entities=entities, event_handler=event_handler, game_map=game_map, player=player)
 +   engine = Engine(event_handler=event_handler, game_map=game_map, player=player)
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>    ...
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
-    <span class="crossed-out-text">npc = Entity(int(screen_width / 2 - 5), int(screen_height / 2), "@", (255, 255, 0))</span>
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
+    <span class="crossed-out-text">npc = Entity(screen_width // 2 - 5, screen_height // 2, "@", (255, 255, 0))</span>
     <span class="crossed-out-text">entities = {npc, player}</span>
 
     game_map = generate_dungeon(
@@ -136,7 +136,7 @@ Because we've modified the definition of `Engine.__init__`, we need to modify `m
     <span class="crossed-out-text">engine = Engine(entities=entities, event_handler=event_handler, game_map=game_map, player=player)</span>
     <span class="new-text">engine = Engine(event_handler=event_handler, game_map=game_map, player=player)</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -203,7 +203,7 @@ class GameMap:
 +       for entity in self.entities:
 +           # Only print entities that are in the FOV
 +           if self.visible[entity.x, entity.y]:
-+               console.print(x=entity.x, y=entity.y, string=entity.char, fg=entity.color)
++               console.print(x=entity.x, y=entity.y, text=entity.char, fg=entity.color)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
@@ -227,7 +227,7 @@ class GameMap:
         <span class="new-text">for entity in self.entities:
             # Only print entities that are in the FOV
             if self.visible[entity.x, entity.y]:
-                console.print(x=entity.x, y=entity.y, string=entity.char, fg=entity.color)</span></pre>
+                console.print(x=entity.x, y=entity.y, text=entity.char, fg=entity.color)</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}
 
@@ -290,7 +290,7 @@ In order to specify the maximum number of monsters that can be spawned into a ro
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
 
     game_map = generate_dungeon(
         max_rooms=max_rooms,
@@ -318,7 +318,7 @@ In order to specify the maximum number of monsters that can be spawned into a ro
 
     event_handler = EventHandler()
 
-    player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
+    player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
 
     game_map = generate_dungeon(
         max_rooms=max_rooms,
@@ -647,7 +647,7 @@ from procgen import generate_dungeon
     ...
     event_handler = EventHandler()
 
--   player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))
+-   player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))
 +   player = copy.deepcopy(entity_factories.player)
 
     game_map = generate_dungeon(
@@ -670,7 +670,7 @@ from procgen import generate_dungeon
     ...
     event_handler = EventHandler()
 
-    <span class="crossed-out-text">player = Entity(int(screen_width / 2), int(screen_height / 2), "@", (255, 255, 255))</span>
+    <span class="crossed-out-text">player = Entity(screen_width // 2, screen_height // 2, "@", (255, 255, 255))</span>
     <span class="new-text">player = copy.deepcopy(entity_factories.player)</span>
 
     game_map = generate_dungeon(
@@ -1012,7 +1012,7 @@ Now that our new actions are in place, we need to modify our `input_handlers.py`
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-from typing import Optional
+from __future__ import annotations
 
 import tcod.event
 
@@ -1020,29 +1020,28 @@ import tcod.event
 +from actions import Action, BumpAction, EscapeAction
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
-    def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
-        raise SystemExit()
+class EventHandler:
+    ...
 
-    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
-        action: Optional[Action] = None
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Action | None:
+        action: Action | None = None
 
         key = event.sym
 
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
 -           action = MovementAction(dx=0, dy=-1)
 +           action = BumpAction(dx=0, dy=-1)
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
 -           action = MovementAction(dx=0, dy=1)
 +           action = BumpAction(dx=0, dy=1)
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
 -           action = MovementAction(dx=-1, dy=0)
 +           action = BumpAction(dx=-1, dy=0)
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
 -           action = MovementAction(dx=1, dy=0)
 +           action = BumpAction(dx=1, dy=0)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction()
 
         # No valid key was pressed
@@ -1050,7 +1049,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>from typing import Optional
+<pre>from __future__ import annotations
 
 import tcod.event
 
@@ -1058,29 +1057,28 @@ import tcod.event
 <span class="new-text">from actions import Action, BumpAction, EscapeAction</span>
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
-    def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
-        raise SystemExit()
+class EventHandler:
+    ...
 
-    def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
-        action: Optional[Action] = None
+    def ev_keydown(self, event: tcod.event.KeyDown) -> Action | None:
+        action: Action | None = None
 
         key = event.sym
 
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
             <span class="crossed-out-text">action = MovementAction(dx=0, dy=-1)</span>
             <span class="new-text">action = BumpAction(dx=0, dy=-1)</span>
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
             <span class="crossed-out-text">action = MovementAction(dx=0, dy=1)</span>
             <span class="new-text">action = BumpAction(dx=0, dy=1)</span>
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
             <span class="crossed-out-text">action = MovementAction(dx=-1, dy=0)</span>
             <span class="new-text">action = BumpAction(dx=-1, dy=0)</span>
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
             <span class="crossed-out-text">action = MovementAction(dx=1, dy=0)</span>
             <span class="new-text">action = BumpAction(dx=1, dy=0)</span>
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction()
 
         # No valid key was pressed

--- a/content/tutorials/tcod/v2/part-6.md
+++ b/content/tutorials/tcod/v2/part-6.md
@@ -6,25 +6,20 @@ draft: false
 
 ## Check your TCOD installation
 
-Before proceeding any further, you'll want to upgrade to TCOD version 11.15, if you don't already have it. This version of TCOD was released *during* the tutorial event, so if you're following along on a weekly basis, you probably *don't* have this version installed!
+This updated version of the tutorial has been reviewed with **Python 3.14.4** and **tcod 21.2.0**. If your local environment is older, upgrade before continuing.
 
 ## Refactoring previous code
 
-After parts 1-5 for this tutorial were written, we decided to change a few things around, to hopefully make the codebase a bit cleaner and easier to extend in the future. Unfortunately, this means that code written in previous parts now has to be modified.
+The original 2020 tutorial introduced a larger refactor at this point because the earlier chapters had been written incrementally during the event. In this updated version, parts 1-5 already use the modernized base APIs, but we still want the same architectural cleanup before combat gets more involved.
 
-I would go back and edit the tutorial text and Github branches to reflect these changes, except for two things:
-
-1. I don't have time at the moment. Writing the sections that get published every week is taking all of my time as it is.
-2. It wouldn't be fair to those who are following this tutorial on a weekly basis.
-
-Someday, when the event is over, the previous parts will be rewritten, and all will be well. But until then, there's several changes that need to be made before proceeding with Part 6.
-
-I won't explain all of the changes (again, time is a limiting factor), but here's the basic ideas:
+Here are the main ideas behind the refactor:
 
 * Event handlers will have the `handle_events` method instead of `Engine`.
 * The game map will have a reference to `Engine`, and entities will have a reference to the map.
 * Actions will be initialized with the entity doing the action
 * Because of the above points, Actions will have a reference to the `Engine`, through `Entity`->`GameMap`->`Engine`
+
+> **Updated from the original:** The original 2020 tutorial used `tcod.event.EventDispatch[Action]` as the base class for `EventHandler`, which was tcod's built-in mechanism for routing events to typed handler methods. That class has been deprecated in recent tcod releases. In this version `EventHandler` defines its own `dispatch` method using Python's `match` statement to achieve the same routing without the deprecated base class.
 
 Make the changes to each file, and when you're finished, verify the project works as it did before.
 
@@ -34,35 +29,43 @@ Make the changes to each file, and when you're finished, verify the project work
 {{< diff-tab >}}
 {{< highlight diff >}}
 +from __future__ import annotations
-
--from typing import Optional
++
 +from typing import Optional, TYPE_CHECKING
-
-import tcod.event
-
-from actions import Action, BumpAction, EscapeAction
-
++
++import tcod.event
++
++from actions import Action, BumpAction, EscapeAction
++
 +if TYPE_CHECKING:
 +   from engine import Engine
-
-
-class EventHandler(tcod.event.EventDispatch[Action]):
++
++
++class EventHandler:
 +   def __init__(self, engine: Engine):
 +       self.engine = engine
-
++
++   def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
++       match event:
++           case tcod.event.Quit():
++               return self.ev_quit(event)
++           case tcod.event.KeyDown():
++               return self.ev_keydown(event)
++           case _:
++               return None
++
 +   def handle_events(self) -> None:
 +       for event in tcod.event.wait():
 +           action = self.dispatch(event)
-
++
 +           if action is None:
 +               continue
-
++
 +           action.perform()
-
++
 +           self.engine.handle_enemy_turns()
 +           self.engine.update_fov()  # Update the FOV before the players next action.
-
-
++
++
     def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
         ...
 
@@ -72,42 +75,50 @@ class EventHandler(tcod.event.EventDispatch[Action]):
         key = event.sym
 
 +       player = self.engine.player
-
-        if key == tcod.event.K_UP:
++
+        if key == tcod.event.KeySym.UP:
 -           action = BumpAction(dx=0, dy=-1)
 +           action = BumpAction(player, dx=0, dy=-1)
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
 -           action = BumpAction(dx=0, dy=1)
 +           action = BumpAction(player, dx=0, dy=1)
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
 -           action = BumpAction(dx=-1, dy=0)
 +           action = BumpAction(player, dx=-1, dy=0)
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
 -           action = BumpAction(dx=1, dy=0)
 +           action = BumpAction(player, dx=1, dy=0)
-
-        elif key == tcod.event.K_ESCAPE:
++
+        elif key == tcod.event.KeySym.ESCAPE:
 -           action = EscapeAction()
 +           action = EscapeAction(player)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre><span class="new-text">from __future__ import annotations</span>
+<pre>from __future__ import annotations
 
-<span class="crossed-out-text">from typing import Optional</span>
-<span class="new-text">from typing import Optional, TYPE_CHECKING</span>
+from typing import Optional, TYPE_CHECKING
 
 import tcod.event
 
 from actions import Action, BumpAction, EscapeAction
 
-<span class="new-text">if TYPE_CHECKING:
-    from engine import Engine</span>
+if TYPE_CHECKING:
+    from engine import Engine
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
-    <span class="new-text">def __init__(self, engine: Engine):
+class EventHandler:
+    def __init__(self, engine: Engine):
         self.engine = engine
+
+    def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
 
     def handle_events(self) -> None:
         for event in tcod.event.wait():
@@ -119,7 +130,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
             action.perform()
 
             self.engine.handle_enemy_turns()
-            self.engine.update_fov()  # Update the FOV before the players next action.</span>
+            self.engine.update_fov()  # Update the FOV before the players next action.
 
 
     def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
@@ -130,22 +141,22 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
         key = event.sym
 
-        <span class="new-text">player = self.engine.player</span>
+        player = self.engine.player
 
-        if key == tcod.event.K_UP:
+        if key == tcod.event.KeySym.UP:
             <span class="crossed-out-text">action = BumpAction(dx=0, dy=-1)</span>
             <span class="new-text">action = BumpAction(player, dx=0, dy=-1)</span>
-        elif key == tcod.event.K_DOWN:
+        elif key == tcod.event.KeySym.DOWN:
             <span class="crossed-out-text">action = BumpAction(dx=0, dy=1)</span>
             <span class="new-text">action = BumpAction(player, dx=0, dy=1)</span>
-        elif key == tcod.event.K_LEFT:
+        elif key == tcod.event.KeySym.LEFT:
             <span class="crossed-out-text">action = BumpAction(dx=-1, dy=0)</span>
             <span class="new-text">action = BumpAction(player, dx=-1, dy=0)</span>
-        elif key == tcod.event.K_RIGHT:
+        elif key == tcod.event.KeySym.RIGHT:
             <span class="crossed-out-text">action = BumpAction(dx=1, dy=0)</span>
             <span class="new-text">action = BumpAction(player, dx=1, dy=0)</span>
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             <span class="crossed-out-text">action = EscapeAction()</span>
             <span class="new-text">action = EscapeAction(player)</span></pre>
 {{</ original-tab >}}
@@ -572,7 +583,7 @@ from procgen import generate_dungeon
 
 -   engine = Engine(event_handler=event_handler, game_map=game_map, player=player)
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
         while True:
             engine.render(console=root_console, context=context)
@@ -621,7 +632,7 @@ from procgen import generate_dungeon
 
     <span class="crossed-out-text">engine = Engine(event_handler=event_handler, game_map=game_map, player=player)</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
         while True:
             engine.render(console=root_console, context=context)
@@ -1547,50 +1558,50 @@ if TYPE_CHECKING:
 
 +MOVE_KEYS = {
 +   # Arrow keys.
-+   tcod.event.K_UP: (0, -1),
-+   tcod.event.K_DOWN: (0, 1),
-+   tcod.event.K_LEFT: (-1, 0),
-+   tcod.event.K_RIGHT: (1, 0),
-+   tcod.event.K_HOME: (-1, -1),
-+   tcod.event.K_END: (-1, 1),
-+   tcod.event.K_PAGEUP: (1, -1),
-+   tcod.event.K_PAGEDOWN: (1, 1),
++   tcod.event.KeySym.UP: (0, -1),
++   tcod.event.KeySym.DOWN: (0, 1),
++   tcod.event.KeySym.LEFT: (-1, 0),
++   tcod.event.KeySym.RIGHT: (1, 0),
++   tcod.event.KeySym.HOME: (-1, -1),
++   tcod.event.KeySym.END: (-1, 1),
++   tcod.event.KeySym.PAGEUP: (1, -1),
++   tcod.event.KeySym.PAGEDOWN: (1, 1),
 +   # Numpad keys.
-+   tcod.event.K_KP_1: (-1, 1),
-+   tcod.event.K_KP_2: (0, 1),
-+   tcod.event.K_KP_3: (1, 1),
-+   tcod.event.K_KP_4: (-1, 0),
-+   tcod.event.K_KP_6: (1, 0),
-+   tcod.event.K_KP_7: (-1, -1),
-+   tcod.event.K_KP_8: (0, -1),
-+   tcod.event.K_KP_9: (1, -1),
++   tcod.event.KeySym.KP_1: (-1, 1),
++   tcod.event.KeySym.KP_2: (0, 1),
++   tcod.event.KeySym.KP_3: (1, 1),
++   tcod.event.KeySym.KP_4: (-1, 0),
++   tcod.event.KeySym.KP_6: (1, 0),
++   tcod.event.KeySym.KP_7: (-1, -1),
++   tcod.event.KeySym.KP_8: (0, -1),
++   tcod.event.KeySym.KP_9: (1, -1),
 +   # Vi keys.
-+   tcod.event.K_h: (-1, 0),
-+   tcod.event.K_j: (0, 1),
-+   tcod.event.K_k: (0, -1),
-+   tcod.event.K_l: (1, 0),
-+   tcod.event.K_y: (-1, -1),
-+   tcod.event.K_u: (1, -1),
-+   tcod.event.K_b: (-1, 1),
-+   tcod.event.K_n: (1, 1),
++   tcod.event.KeySym.h: (-1, 0),
++   tcod.event.KeySym.j: (0, 1),
++   tcod.event.KeySym.k: (0, -1),
++   tcod.event.KeySym.l: (1, 0),
++   tcod.event.KeySym.y: (-1, -1),
++   tcod.event.KeySym.u: (1, -1),
++   tcod.event.KeySym.b: (-1, 1),
++   tcod.event.KeySym.n: (1, 1),
 +}
 
 +WAIT_KEYS = {
-+   tcod.event.K_PERIOD,
-+   tcod.event.K_KP_5,
-+   tcod.event.K_CLEAR,
++   tcod.event.KeySym.PERIOD,
++   tcod.event.KeySym.KP_5,
++   tcod.event.KeySym.CLEAR,
 +}
 
 
         ...
 
--       if key == tcod.event.K_UP:
+-       if key == tcod.event.KeySym.UP:
 -           action = BumpAction(dx=0, dy=-1)
--       elif key == tcod.event.K_DOWN:
+-       elif key == tcod.event.KeySym.DOWN:
 -           action = BumpAction(dx=0, dy=1)
--       elif key == tcod.event.K_LEFT:
+-       elif key == tcod.event.KeySym.LEFT:
 -           action = BumpAction(dx=-1, dy=0)
--       elif key == tcod.event.K_RIGHT:
+-       elif key == tcod.event.KeySym.RIGHT:
 -           action = BumpAction(dx=1, dy=0)
 +       if key in MOVE_KEYS:
 +           dx, dy = MOVE_KEYS[key]
@@ -1617,50 +1628,50 @@ if TYPE_CHECKING:
 
 <span class="new-text">MOVE_KEYS = {
     # Arrow keys.
-    tcod.event.K_UP: (0, -1),
-    tcod.event.K_DOWN: (0, 1),
-    tcod.event.K_LEFT: (-1, 0),
-    tcod.event.K_RIGHT: (1, 0),
-    tcod.event.K_HOME: (-1, -1),
-    tcod.event.K_END: (-1, 1),
-    tcod.event.K_PAGEUP: (1, -1),
-    tcod.event.K_PAGEDOWN: (1, 1),
+    tcod.event.KeySym.UP: (0, -1),
+    tcod.event.KeySym.DOWN: (0, 1),
+    tcod.event.KeySym.LEFT: (-1, 0),
+    tcod.event.KeySym.RIGHT: (1, 0),
+    tcod.event.KeySym.HOME: (-1, -1),
+    tcod.event.KeySym.END: (-1, 1),
+    tcod.event.KeySym.PAGEUP: (1, -1),
+    tcod.event.KeySym.PAGEDOWN: (1, 1),
     # Numpad keys.
-    tcod.event.K_KP_1: (-1, 1),
-    tcod.event.K_KP_2: (0, 1),
-    tcod.event.K_KP_3: (1, 1),
-    tcod.event.K_KP_4: (-1, 0),
-    tcod.event.K_KP_6: (1, 0),
-    tcod.event.K_KP_7: (-1, -1),
-    tcod.event.K_KP_8: (0, -1),
-    tcod.event.K_KP_9: (1, -1),
+    tcod.event.KeySym.KP_1: (-1, 1),
+    tcod.event.KeySym.KP_2: (0, 1),
+    tcod.event.KeySym.KP_3: (1, 1),
+    tcod.event.KeySym.KP_4: (-1, 0),
+    tcod.event.KeySym.KP_6: (1, 0),
+    tcod.event.KeySym.KP_7: (-1, -1),
+    tcod.event.KeySym.KP_8: (0, -1),
+    tcod.event.KeySym.KP_9: (1, -1),
     # Vi keys.
-    tcod.event.K_h: (-1, 0),
-    tcod.event.K_j: (0, 1),
-    tcod.event.K_k: (0, -1),
-    tcod.event.K_l: (1, 0),
-    tcod.event.K_y: (-1, -1),
-    tcod.event.K_u: (1, -1),
-    tcod.event.K_b: (-1, 1),
-    tcod.event.K_n: (1, 1),
+    tcod.event.KeySym.h: (-1, 0),
+    tcod.event.KeySym.j: (0, 1),
+    tcod.event.KeySym.k: (0, -1),
+    tcod.event.KeySym.l: (1, 0),
+    tcod.event.KeySym.y: (-1, -1),
+    tcod.event.KeySym.u: (1, -1),
+    tcod.event.KeySym.b: (-1, 1),
+    tcod.event.KeySym.n: (1, 1),
 }
 
 WAIT_KEYS = {
-    tcod.event.K_PERIOD,
-    tcod.event.K_KP_5,
-    tcod.event.K_CLEAR,
+    tcod.event.KeySym.PERIOD,
+    tcod.event.KeySym.KP_5,
+    tcod.event.KeySym.CLEAR,
 }</span>
 
 
         ...
 
-        <span class="crossed-out-text">if key == tcod.event.K_UP:</span>
+        <span class="crossed-out-text">if key == tcod.event.KeySym.UP:</span>
             <span class="crossed-out-text">action = BumpAction(player, dx=0, dy=-1)</span>
-        <span class="crossed-out-text">elif key == tcod.event.K_DOWN:</span>
+        <span class="crossed-out-text">elif key == tcod.event.KeySym.DOWN:</span>
             <span class="crossed-out-text">action = BumpAction(player, dx=0, dy=1)</span>
-        <span class="crossed-out-text">elif key == tcod.event.K_LEFT:</span>
+        <span class="crossed-out-text">elif key == tcod.event.KeySym.LEFT:</span>
             <span class="crossed-out-text">action = BumpAction(player, dx=-1, dy=0)</span>
-        <span class="crossed-out-text">elif key == tcod.event.K_RIGHT:</span>
+        <span class="crossed-out-text">elif key == tcod.event.KeySym.RIGHT:</span>
             <span class="crossed-out-text">action = BumpAction(player, dx=1, dy=0)</span>
         <span class="new-text">if key in MOVE_KEYS:
             dx, dy = MOVE_KEYS[key]
@@ -2166,9 +2177,9 @@ In order to actually take advantage of the rendering order, we'll need to modify
 -       for entity in self.entities:
 +       for entity in entities_sorted_for_rendering:
             if self.visible[entity.x, entity.y]:
--               console.print(x=entity.x, y=entity.y, string=entity.char, fg=entity.color)
+-               console.print(x=entity.x, y=entity.y, text=entity.char, fg=entity.color)
 +               console.print(
-+                   x=entity.x, y=entity.y, string=entity.char, fg=entity.color
++                   x=entity.x, y=entity.y, text=entity.char, fg=entity.color
 +               )
 
 {{</ highlight >}}
@@ -2196,9 +2207,9 @@ In order to actually take advantage of the rendering order, we'll need to modify
         <span class="crossed-out-text">for entity in self.entities:</span>
         <span class="new-text">for entity in entities_sorted_for_rendering:</span>
             if self.visible[entity.x, entity.y]:
-                <span class="crossed-out-text">console.print(x=entity.x, y=entity.y, string=entity.char, fg=entity.color)</span>
+                <span class="crossed-out-text">console.print(x=entity.x, y=entity.y, text=entity.char, fg=entity.color)</span>
                 <span class="new-text">console.print(
-                    x=entity.x, y=entity.y, string=entity.char, fg=entity.color
+                    x=entity.x, y=entity.y, text=entity.char, fg=entity.color
                 )</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}
@@ -2285,7 +2296,7 @@ class Engine:
 +       console.print(
 +           x=1,
 +           y=47,
-+           string=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
++           text=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
 +       )
 
         context.present(console)
@@ -2313,7 +2324,7 @@ class Engine:
         <span class="new-text">console.print(
             x=1,
             y=47,
-            string=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
+            text=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
         )</span>
 
         context.present(console)
@@ -2336,7 +2347,7 @@ Open up `input_handlers.py` and make the following adjustments:
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
@@ -2376,7 +2387,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
         elif key in WAIT_KEYS:
             action = WaitAction(player)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction(player)
 
         # No valid key was pressed
@@ -2398,7 +2409,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
 +       key = event.sym
 
-+       if key == tcod.event.K_ESCAPE:
++       if key == tcod.event.KeySym.ESCAPE:
 +           action = EscapeAction(self.engine.player)
 
 +       # No valid key was pressed
@@ -2406,7 +2417,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>class EventHandler(tcod.event.EventDispatch[Action]):
+<pre>class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
@@ -2446,7 +2457,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
         elif key in WAIT_KEYS:
             action = WaitAction(player)
 
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction(player)
 
         # No valid key was pressed
@@ -2468,7 +2479,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
         key = event.sym
 
-        if key == tcod.event.K_ESCAPE:
+        if key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction(self.engine.player)
 
         # No valid key was pressed

--- a/content/tutorials/tcod/v2/part-7.md
+++ b/content/tutorials/tcod/v2/part-7.md
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING
 import color
 
 if TYPE_CHECKING:
-    from tcod import Console
+    from tcod.console import Console
 
 
 def render_bar(
@@ -59,7 +59,7 @@ def render_bar(
         )
 
     console.print(
-        x=1, y=45, string=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
+        x=1, y=45, text=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
     )
 ```
 
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
 -       console.print(
 -           x=1,
 -           y=47,
--           string=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
+-           text=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",
 -       )
 
         context.present(console)
@@ -121,7 +121,7 @@ if TYPE_CHECKING:
         <span class="crossed-out-text">console.print(</span>
             <span class="crossed-out-text">x=1,</span>
             <span class="crossed-out-text">y=47,</span>
-            <span class="crossed-out-text">string=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",</span>
+            <span class="crossed-out-text">text=f"HP: {self.player.fighter.hp}/{self.player.fighter.max_hp}",</span>
         <span class="crossed-out-text">)</span>
 
         context.present(console)
@@ -179,7 +179,7 @@ class MessageLog:
             self.messages.append(Message(text, fg))
 
     def render(
-        self, console: tcod.Console, x: int, y: int, width: int, height: int,
+        self, console: tcod.console.Console, x: int, y: int, width: int, height: int,
     ) -> None:
         """Render this log over the given area.
         `x`, `y`, `width`, `height` is the rectangular region to render onto
@@ -189,7 +189,7 @@ class MessageLog:
 
     @staticmethod
     def render_messages(
-        console: tcod.Console,
+        console: tcod.console.Console,
         x: int,
         y: int,
         width: int,
@@ -204,7 +204,7 @@ class MessageLog:
 
         for message in reversed(messages):
             for line in reversed(textwrap.wrap(message.full_text, width)):
-                console.print(x=x, y=y + y_offset, string=line, fg=message.fg)
+                console.print(x=x, y=y + y_offset, text=line, fg=message.fg)
                 y_offset -= 1
                 if y_offset < 0:
                     return  # No more space to print messages.
@@ -266,7 +266,7 @@ If we are allowing stacking, and the added message matches the previous message,
 
 ```py3
     def render(
-        self, console: tcod.Console, x: int, y: int, width: int, height: int,
+        self, console: tcod.console.Console, x: int, y: int, width: int, height: int,
     ) -> None:
         """Render this log over the given area.
         `x`, `y`, `width`, `height` is the rectangular region to render onto
@@ -276,7 +276,7 @@ If we are allowing stacking, and the added message matches the previous message,
 
     @staticmethod
     def render_messages(
-        console: tcod.Console,
+        console: tcod.console.Console,
         x: int,
         y: int,
         width: int,
@@ -291,7 +291,7 @@ If we are allowing stacking, and the added message matches the previous message,
 
         for message in reversed(messages):
             for line in reversed(textwrap.wrap(message.full_text, width)):
-                console.print(x=x, y=y + y_offset, string=line, fg=message.fg)
+                console.print(x=x, y=y + y_offset, text=line, fg=message.fg)
                 y_offset -= 1
                 if y_offset < 0:
                     return  # No more space to print messages.
@@ -394,7 +394,7 @@ import entity_factories
 +       "Hello and welcome, adventurer, to yet another dungeon!", color.welcome_text
 +   )
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -424,7 +424,7 @@ import entity_factories
         "Hello and welcome, adventurer, to yet another dungeon!", color.welcome_text
     )</span>
 
-    with tcod.context.new_terminal(
+    with tcod.context.new(
         ...</pre>
 
 
@@ -586,7 +586,7 @@ Edit `main.py` like this:
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-        root_console = tcod.Console(screen_width, screen_height, order="F")
+        root_console = tcod.console.Console(screen_width, screen_height, order="F")
         while True:
 +           root_console.clear()
 +           engine.event_handler.on_render(console=root_console)
@@ -598,7 +598,7 @@ Edit `main.py` like this:
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>        root_console = tcod.Console(screen_width, screen_height, order="F")
+<pre>        root_console = tcod.console.Console(screen_width, screen_height, order="F")
         while True:
             <span class="new-text">root_console.clear()
             engine.event_handler.on_render(console=root_console)
@@ -619,22 +619,28 @@ Now let's modify `input_handlers.py` to contain the methods we're calling in `ma
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
--   def handle_events(self) -> None:
--       raise NotImplementedError()
-
++   def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
++       match event:
++           case tcod.event.Quit():
++               return self.ev_quit(event)
++           case tcod.event.KeyDown():
++               return self.ev_keydown(event)
++           case _:
++               return None
++
 +   def handle_events(self, context: tcod.context.Context) -> None:
 +       for event in tcod.event.wait():
-+           context.convert_event(event)
++           event = context.convert_event(event)
 +           self.dispatch(event)
 
     def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
         raise SystemExit()
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def on_render(self, console: tcod.console.Console) -> None:
 +       self.engine.render(console)
 
 
@@ -642,7 +648,7 @@ class MainGameEventHandler(EventHandler):
 -   def handle_events(self) -> None:
 +   def handle_events(self, context: tcod.context.Context) -> None:
         for event in tcod.event.wait():
-+           context.convert_event(event)
++           event = context.convert_event(event)
 
             action = self.dispatch(event)
             ...
@@ -655,22 +661,28 @@ class GameOverEventHandler(EventHandler):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>class EventHandler(tcod.event.EventDispatch[Action]):
+<pre>class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
-    <span class="crossed-out-text">def handle_events(self) -> None:</span>
-        <span class="crossed-out-text">raise NotImplementedError()</span>
+    def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
 
     <span class="new-text">def handle_events(self, context: tcod.context.Context) -> None:
         for event in tcod.event.wait():
-            context.convert_event(event)
+            event = context.convert_event(event)
             self.dispatch(event)</span>
 
     def ev_quit(self, event: tcod.event.Quit) -> Optional[Action]:
         raise SystemExit()
 
-    <span class="new-text">def on_render(self, console: tcod.Console) -> None:
+    <span class="new-text">def on_render(self, console: tcod.console.Console) -> None:
         self.engine.render(console)</span>
 
 
@@ -678,7 +690,7 @@ class MainGameEventHandler(EventHandler):
     <span class="crossed-out-text">def handle_events(self) -> None:</span>
     <span class="new-text">def handle_events(self, context: tcod.context.Context) -> None:</span>
         for event in tcod.event.wait():
-            <span class="new-text">context.convert_event(event)</span>
+            <span class="new-text">event = context.convert_event(event)</span>
 
             action = self.dispatch(event)
             ...
@@ -691,11 +703,11 @@ class GameOverEventHandler(EventHandler):
 {{</ original-tab >}}
 {{</ codetab >}}
 
-We're modifying the `handle_events` method in `EventHandler` to actually have an implementation. It iterates through the events, and uses `context.convert_event` to give the event knowledge on the mouse position. It then dispatches that event, to be handled like normal.
+We're modifying the `handle_events` method in `EventHandler` to actually have an implementation. It iterates through the events, converts each one with `context.convert_event`, and then dispatches the converted event as usual.
 
 `on_render` just tells the `Engine` class to call its render method, using the given console.
 
-`MainGameEventHandler` and `GameOverEventHandler` have small changes to their `handle_events` methods to match the signature of `EventHandler`, and `MainGameEventHandler` also uses `context.convert_event`.
+`MainGameEventHandler` and `GameOverEventHandler` have small changes to their `handle_events` methods to match the signature of `EventHandler`, and `MainGameEventHandler` also reuses the converted event before dispatching it.
 
 We're no longer passing the `context` to the `Engine` class's `render` method, so let's change the method now:
 
@@ -796,13 +808,25 @@ There's an easy way: by overriding a method in `EventHandler`, which is called `
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
+    def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.MouseMotion():
+                self.ev_mousemotion(event)
+                return None
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
+
     def handle_events(self, context: tcod.context.Context) -> None:
         for event in tcod.event.wait():
-            context.convert_event(event)
+            event = context.convert_event(event)
             self.dispatch(event)
 
 +   def ev_mousemotion(self, event: tcod.event.MouseMotion) -> None:
@@ -814,13 +838,25 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>class EventHandler(tcod.event.EventDispatch[Action]):
+<pre>class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
 
+    def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.MouseMotion():
+                self.ev_mousemotion(event)
+                return None
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
+
     def handle_events(self, context: tcod.context.Context) -> None:
         for event in tcod.event.wait():
-            context.convert_event(event)
+            event = context.convert_event(event)
             self.dispatch(event)
 
     <span class="new-text">def ev_mousemotion(self, event: tcod.event.MouseMotion) -> None:
@@ -846,7 +882,7 @@ from typing import TYPE_CHECKING
 import color
 
 if TYPE_CHECKING:
-    from tcod import Console
+    from tcod.console import Console
 +   from engine import Engine
 +   from game_map import GameMap
 
@@ -875,7 +911,7 @@ def render_bar(
         )
 
     console.print(
-        x=1, y=45, string=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
+        x=1, y=45, text=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
     )
 
 
@@ -888,7 +924,7 @@ def render_bar(
 +       x=mouse_x, y=mouse_y, game_map=engine.game_map
 +   )
 
-+   console.print(x=x, y=y, string=names_at_mouse_location)
++   console.print(x=x, y=y, text=names_at_mouse_location)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
@@ -899,7 +935,7 @@ from typing import TYPE_CHECKING
 import color
 
 if TYPE_CHECKING:
-    from tcod import Console
+    from tcod.console import Console
     <span class="new-text">from engine import Engine
     from game_map import GameMap
 
@@ -928,7 +964,7 @@ def render_bar(
         )
 
     console.print(
-        x=1, y=45, string=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
+        x=1, y=45, text=f"HP: {current_value}/{maximum_value}", fg=color.bar_text
     )
 
 
@@ -941,7 +977,7 @@ def render_bar(
         x=mouse_x, y=mouse_y, game_map=engine.game_map
     )
 
-    console.print(x=x, y=y, string=names_at_mouse_location)</span></pre>
+    console.print(x=x, y=y, text=names_at_mouse_location)</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}
 
@@ -1019,10 +1055,10 @@ class GameOverEventHandler(EventHandler):
 
 
 +CURSOR_Y_KEYS = {
-+   tcod.event.K_UP: -1,
-+   tcod.event.K_DOWN: 1,
-+   tcod.event.K_PAGEUP: -10,
-+   tcod.event.K_PAGEDOWN: 10,
++   tcod.event.KeySym.UP: -1,
++   tcod.event.KeySym.DOWN: 1,
++   tcod.event.KeySym.PAGEUP: -10,
++   tcod.event.KeySym.PAGEDOWN: 10,
 +}
 
 
@@ -1034,15 +1070,19 @@ class GameOverEventHandler(EventHandler):
 +       self.log_length = len(engine.message_log.messages)
 +       self.cursor = self.log_length - 1
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def on_render(self, console: tcod.console.Console) -> None:
 +       super().on_render(console)  # Draw the main state as the background.
 
-+       log_console = tcod.Console(console.width - 6, console.height - 6)
++       log_console = tcod.console.Console(console.width - 6, console.height - 6)
 
 +       # Draw a frame with a custom banner title.
 +       log_console.draw_frame(0, 0, log_console.width, log_console.height)
-+       log_console.print_box(
-+           0, 0, log_console.width, 1, "┤Message history├", alignment=tcod.CENTER
++       log_console.print(
++           x=0,
++           y=0,
++           text="Message history",
++           width=log_console.width,
++           alignment=tcod.constants.CENTER,
 +       )
 
 +       # Render the message log using the cursor parameter.
@@ -1069,9 +1109,9 @@ class GameOverEventHandler(EventHandler):
 +           else:
 +               # Otherwise move while staying clamped to the bounds of the history log.
 +               self.cursor = max(0, min(self.cursor + adjust, self.log_length - 1))
-+       elif event.sym == tcod.event.K_HOME:
++       elif event.sym == tcod.event.KeySym.HOME:
 +           self.cursor = 0  # Move directly to the top message.
-+       elif event.sym == tcod.event.K_END:
++       elif event.sym == tcod.event.KeySym.END:
 +           self.cursor = self.log_length - 1  # Move directly to the last message.
 +       else:  # Any other key moves back to the main game state.
 +           self.engine.event_handler = MainGameEventHandler(self.engine)
@@ -1083,10 +1123,10 @@ class GameOverEventHandler(EventHandler):
 
 
 <span class="new-text">CURSOR_Y_KEYS = {
-    tcod.event.K_UP: -1,
-    tcod.event.K_DOWN: 1,
-    tcod.event.K_PAGEUP: -10,
-    tcod.event.K_PAGEDOWN: 10,
+    tcod.event.KeySym.UP: -1,
+    tcod.event.KeySym.DOWN: 1,
+    tcod.event.KeySym.PAGEUP: -10,
+    tcod.event.KeySym.PAGEDOWN: 10,
 }
 
 
@@ -1098,15 +1138,19 @@ class HistoryViewer(EventHandler):
         self.log_length = len(engine.message_log.messages)
         self.cursor = self.log_length - 1
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         super().on_render(console)  # Draw the main state as the background.
 
-        log_console = tcod.Console(console.width - 6, console.height - 6)
+        log_console = tcod.console.Console(console.width - 6, console.height - 6)
 
         # Draw a frame with a custom banner title.
         log_console.draw_frame(0, 0, log_console.width, log_console.height)
-        log_console.print_box(
-            0, 0, log_console.width, 1, "┤Message history├", alignment=tcod.CENTER
+        log_console.print(
+            x=0,
+            y=0,
+            text="Message history",
+            width=log_console.width,
+            alignment=tcod.constants.CENTER,
         )
 
         # Render the message log using the cursor parameter.
@@ -1133,9 +1177,9 @@ class HistoryViewer(EventHandler):
             else:
                 # Otherwise move while staying clamped to the bounds of the history log.
                 self.cursor = max(0, min(self.cursor + adjust, self.log_length - 1))
-        elif event.sym == tcod.event.K_HOME:
+        elif event.sym == tcod.event.KeySym.HOME:
             self.cursor = 0  # Move directly to the top message.
-        elif event.sym == tcod.event.K_END:
+        elif event.sym == tcod.event.KeySym.END:
             self.cursor = self.log_length - 1  # Move directly to the last message.
         else:  # Any other key moves back to the main game state.
             self.engine.event_handler = MainGameEventHandler(self.engine)</span></pre>
@@ -1148,17 +1192,17 @@ To show this new view, all we need to do is this, in `MainGameEventHandler`:
 {{< diff-tab >}}
 {{< highlight diff >}}
         ...
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction(player)
-+       elif key == tcod.event.K_v:
++       elif key == tcod.event.KeySym.v:
 +           self.engine.event_handler = HistoryViewer(self.engine)
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>        ...
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             action = EscapeAction(player)
-        <span class="new-text">elif key == tcod.event.K_v:
+        <span class="new-text">elif key == tcod.event.KeySym.v:
             self.engine.event_handler = HistoryViewer(self.engine)</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}

--- a/content/tutorials/tcod/v2/part-8.md
+++ b/content/tutorials/tcod/v2/part-8.md
@@ -75,7 +75,7 @@ class MessageLog:
     ...
 
     def render(
-        self, console: tcod.Console, x: int, y: int, width: int, height: int,
+        self, console: tcod.console.Console, x: int, y: int, width: int, height: int,
     ) -> None:
         """Render this log over the given area.
 
@@ -96,7 +96,7 @@ class MessageLog:
 +   @classmethod
     def render_messages(
 +       cls,
-        console: tcod.Console,
+        console: tcod.console.Console,
         x: int,
         y: int,
         width: int,
@@ -113,7 +113,7 @@ class MessageLog:
         for message in reversed(messages):
 -           for line in reversed(textwrap.wrap(message.full_text, width)):
 +           for line in reversed(list(cls.wrap(message.full_text, width))):
-                console.print(x=x, y=y + y_offset, string=line, fg=message.fg)
+                console.print(x=x, y=y + y_offset, text=line, fg=message.fg)
                 y_offset -= 1
                 if y_offset < 0:
                     return  # No more space to print messages.
@@ -134,7 +134,7 @@ class MessageLog:
     ...
 
     def render(
-        self, console: tcod.Console, x: int, y: int, width: int, height: int,
+        self, console: tcod.console.Console, x: int, y: int, width: int, height: int,
     ) -> None:
         """Render this log over the given area.
 
@@ -155,7 +155,7 @@ class MessageLog:
     <span class="new-text">@classmethod</span>
     def render_messages(
         <span class="new-text">cls,</span>
-        console: tcod.Console,
+        console: tcod.console.Console,
         x: int,
         y: int,
         width: int,
@@ -172,7 +172,7 @@ class MessageLog:
         for message in reversed(messages):
             <span class="crossed-out-text">for line in reversed(textwrap.wrap(message.full_text, width)):</span>
             <span class="new-text">for line in reversed(list(cls.wrap(message.full_text, width))):</span>
-                console.print(x=x, y=y + y_offset, string=line, fg=message.fg)
+                console.print(x=x, y=y + y_offset, text=line, fg=message.fg)
                 y_offset -= 1
                 if y_offset < 0:
                     return  # No more space to print messages.</pre>
@@ -730,7 +730,7 @@ import tcod
 
 +           try:
 +               for event in tcod.event.wait():
-+                   context.convert_event(event)
++                   event = context.convert_event(event)
 +                   engine.event_handler.handle_events(event)
 +           except Exception:  # Handle exceptions in game.
 +               traceback.print_exc()  # Print error to stderr.
@@ -752,7 +752,7 @@ import tcod
 
             <span class="new-text">try:
                 for event in tcod.event.wait():
-                    context.convert_event(event)
+                    event = context.convert_event(event)
                     engine.event_handler.handle_events(event)
             except Exception:  # Handle exceptions in game.
                 traceback.print_exc()  # Print error to stderr.
@@ -763,6 +763,8 @@ import tcod
 {{</ codetab >}}
 
 This is a generalized, catch all solution, which will print *all* exceptions to the message log, not just instances of `Impossible`. This can be helpful for debugging your game, or getting error reports from users.
+
+> **Updated from the original:** The original tutorial called `context.convert_event(event)` inside each `handle_events` method without capturing the return value, so the converted event (which carries mouse-position information) was silently discarded. This has been corrected throughout: `event = context.convert_event(event)` is now used so the converted event is actually passed to `dispatch`.
 
 However, this solution doesn't mesh with our current implementation of the `EventHandler`. `EventHandler` currently loops through the events and converts them (to get the mouse information). We'll need to edit a few things in `input_handlers.py` to get back on track.
 
@@ -782,9 +784,26 @@ import tcod
 -from actions import Action, BumpAction, EscapeAction, WaitAction
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
+
++   def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
++       match event:
++           case tcod.event.Quit():
++               return self.ev_quit(event)
++           case tcod.event.MouseMotion():
++               self.ev_mousemotion(event)
++               return None
++           case tcod.event.MouseButtonDown():
++               return self.ev_mousebuttondown(event)
++           case tcod.event.KeyDown():
++               return self.ev_keydown(event)
++           case _:
++               return None
++
++   def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
++       return None
 
 +   def handle_events(self, event: tcod.event.Event) -> None:
 +       self.handle_action(self.dispatch(event))
@@ -810,7 +829,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
 -   def handle_events(self, context: tcod.context.Context) -> None:
 -       for event in tcod.event.wait():
--           context.convert_event(event)
+-           event = context.convert_event(event)
 -           self.dispatch(event)
 
     ...
@@ -819,7 +838,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 class MainGameEventHandler(EventHandler):
 -   def handle_events(self, context: tcod.context.Context) -> None:
 -       for event in tcod.event.wait():
--           context.convert_event(event)
+-           event = context.convert_event(event)
 
 -           action = self.dispatch(event)
 
@@ -849,13 +868,13 @@ class GameOverEventHandler(EventHandler):
 
 -       key = event.sym
 
--       if key == tcod.event.K_ESCAPE:
+-       if key == tcod.event.KeySym.ESCAPE:
 -           action = EscapeAction(self.engine.player)
 
 -       # No valid key was pressed
 -       return action
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> None:
-+       if event.sym == tcod.event.K_ESCAPE:
++       if event.sym == tcod.event.KeySym.ESCAPE:
 +           raise SystemExit()
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -873,9 +892,26 @@ import exceptions</span>
 <span class="crossed-out-text">from actions import Action, BumpAction, EscapeAction, WaitAction</span>
 
 
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     def __init__(self, engine: Engine):
         self.engine = engine
+
+    def dispatch(self, event: tcod.event.Event) -> Optional[Action]:
+        match event:
+            case tcod.event.Quit():
+                return self.ev_quit(event)
+            case tcod.event.MouseMotion():
+                self.ev_mousemotion(event)
+                return None
+            case tcod.event.MouseButtonDown():
+                return self.ev_mousebuttondown(event)
+            case tcod.event.KeyDown():
+                return self.ev_keydown(event)
+            case _:
+                return None
+
+    def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
+        return None
 
     <span class="new-text">def handle_events(self, event: tcod.event.Event) -> None:
         self.handle_action(self.dispatch(event))
@@ -901,7 +937,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 
     <span class="crossed-out-text">def handle_events(self, context: tcod.context.Context) -> None:</span>
         <span class="crossed-out-text">for event in tcod.event.wait():</span>
-            <span class="crossed-out-text">context.convert_event(event)</span>
+            <span class="crossed-out-text">event = context.convert_event(event)</span>
             <span class="crossed-out-text">self.dispatch(event)</span>
 
     ...
@@ -910,7 +946,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 class MainGameEventHandler(EventHandler):
     <span class="crossed-out-text">def handle_events(self, context: tcod.context.Context) -> None:</span>
         <span class="crossed-out-text">for event in tcod.event.wait():</span>
-            <span class="crossed-out-text">context.convert_event(event)</span>
+            <span class="crossed-out-text">event = context.convert_event(event)</span>
 
             <span class="crossed-out-text">action = self.dispatch(event)</span>
 
@@ -940,16 +976,18 @@ class GameOverEventHandler(EventHandler):
 
         <span class="crossed-out-text">key = event.sym</span>
 
-        <span class="crossed-out-text">if key == tcod.event.K_ESCAPE:</span>
+        <span class="crossed-out-text">if key == tcod.event.KeySym.ESCAPE:</span>
             <span class="crossed-out-text">action = EscapeAction(self.engine.player)</span>
 
         <span class="crossed-out-text"># No valid key was pressed</span>
         <span class="crossed-out-text">return action</span>
     <span class="new-text">def ev_keydown(self, event: tcod.event.KeyDown) -> None:
-        if event.sym == tcod.event.K_ESCAPE:
+        if event.sym == tcod.event.KeySym.ESCAPE:
             raise SystemExit()</span></pre>
 {{</ original-tab >}}
 {{</ codetab >}}
+
+> **Updated from the original:** The original tutorial kept `EventHandler` inheriting from `tcod.event.EventDispatch[Action]`, which handled event routing automatically. Because `EventDispatch` is deprecated in recent tcod releases, this version adds an explicit `dispatch` method using Python's `match` statement. Mouse events (`MouseMotion`, `MouseButtonDown`) are added to the dispatch here so they are available for the targeting system introduced later in this chapter.
 
 Now that we've got our event handlers updated, let's actually put the `Impossible` exception to good use. We can start by editing `actions.py` to make use of it when the player tries to move into an invalid area:
 
@@ -1925,10 +1963,10 @@ from actions import (
 ...
 
         ...
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
             self.engine.event_handler = HistoryViewer(self.engine)
 
-+       elif key == tcod.event.K_g:
++       elif key == tcod.event.KeySym.g:
 +           action = PickupAction(player)
 
         # No valid key was pressed
@@ -1946,10 +1984,10 @@ from actions import (
 ...
 
         ...
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
             self.engine.event_handler = HistoryViewer(self.engine)
 
-        <span class="new-text">elif key == tcod.event.K_g:
+        <span class="new-text">elif key == tcod.event.KeySym.g:
             action = PickupAction(player)</span>
 
         # No valid key was pressed
@@ -1968,7 +2006,7 @@ To start, let's create a new event handler, which will return to the `MainGameEv
 {{< codetab >}}
 {{< diff-tab >}}
 {{< highlight diff >}}
-class EventHandler(tcod.event.EventDispatch[Action]):
+class EventHandler:
     ...
 
 
@@ -1985,12 +2023,12 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
 +       """By default any key exits this input handler."""
 +       if event.sym in {  # Ignore modifier keys.
-+           tcod.event.K_LSHIFT,
-+           tcod.event.K_RSHIFT,
-+           tcod.event.K_LCTRL,
-+           tcod.event.K_RCTRL,
-+           tcod.event.K_LALT,
-+           tcod.event.K_RALT,
++           tcod.event.KeySym.LSHIFT,
++           tcod.event.KeySym.RSHIFT,
++           tcod.event.KeySym.LCTRL,
++           tcod.event.KeySym.RCTRL,
++           tcod.event.KeySym.LALT,
++           tcod.event.KeySym.RALT,
 +       }:
 +           return None
 +       return self.on_exit()
@@ -2009,7 +2047,7 @@ class EventHandler(tcod.event.EventDispatch[Action]):
 {{</ highlight >}}
 {{</ diff-tab >}}
 {{< original-tab >}}
-<pre>class EventHandler(tcod.event.EventDispatch[Action]):
+<pre>class EventHandler:
     ...
 
 
@@ -2026,12 +2064,12 @@ class EventHandler(tcod.event.EventDispatch[Action]):
     def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
         """By default any key exits this input handler."""
         if event.sym in {  # Ignore modifier keys.
-            tcod.event.K_LSHIFT,
-            tcod.event.K_RSHIFT,
-            tcod.event.K_LCTRL,
-            tcod.event.K_RCTRL,
-            tcod.event.K_LALT,
-            tcod.event.K_RALT,
+            tcod.event.KeySym.LSHIFT,
+            tcod.event.KeySym.RSHIFT,
+            tcod.event.KeySym.LCTRL,
+            tcod.event.KeySym.RCTRL,
+            tcod.event.KeySym.LALT,
+            tcod.event.KeySym.RALT,
         }:
             return None
         return self.on_exit()
@@ -2075,7 +2113,7 @@ class AskUserEventHandler(EventHandler):
 
 +   TITLE = "<missing title>"
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def on_render(self, console: tcod.console.Console) -> None:
 +       """Render an inventory menu, which displays the items in the inventory, and the letter to select them.
 +       Will move to a different position based on where the player is located, so the player can always see where
 +       they are.
@@ -2118,9 +2156,9 @@ class AskUserEventHandler(EventHandler):
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
 +       player = self.engine.player
 +       key = event.sym
-+       index = key - tcod.event.K_a
++       index = key - tcod.event.KeySym.a
 
-+       if 0 <= index <= 26:
++       if 0 <= index < 26:
 +           try:
 +               selected_item = player.inventory.items[index]
 +           except IndexError:
@@ -2153,7 +2191,7 @@ class AskUserEventHandler(EventHandler):
 
     TITLE = "&lt;missing title&gt;"
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         """Render an inventory menu, which displays the items in the inventory, and the letter to select them.
         Will move to a different position based on where the player is located, so the player can always see where
         they are.
@@ -2196,9 +2234,9 @@ class AskUserEventHandler(EventHandler):
     def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
         player = self.engine.player
         key = event.sym
-        index = key - tcod.event.K_a
+        index = key - tcod.event.KeySym.a
 
-        if 0 <= index <= 26:
+        if 0 <= index < 26:
             try:
                 selected_item = player.inventory.items[index]
             except IndexError:
@@ -2349,12 +2387,12 @@ All that's left now is to utilize these event handlers, based on the key we pres
 {{< diff-tab >}}
 {{< highlight diff >}}
         ...
-        elif key == tcod.event.K_g:
+        elif key == tcod.event.KeySym.g:
             action = PickupAction(player)
 
-+       elif key == tcod.event.K_i:
++       elif key == tcod.event.KeySym.i:
 +           self.engine.event_handler = InventoryActivateHandler(self.engine)
-+       elif key == tcod.event.K_d:
++       elif key == tcod.event.KeySym.d:
 +           self.engine.event_handler = InventoryDropHandler(self.engine)
 
         # No valid key was pressed
@@ -2363,12 +2401,12 @@ All that's left now is to utilize these event handlers, based on the key we pres
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>        ...
-        elif key == tcod.event.K_g:
+        elif key == tcod.event.KeySym.g:
             action = PickupAction(player)
 
-        <span class="new-text">elif key == tcod.event.K_i:
+        <span class="new-text">elif key == tcod.event.KeySym.i:
             self.engine.event_handler = InventoryActivateHandler(self.engine)
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
             self.engine.event_handler = InventoryDropHandler(self.engine)</span>
 
         # No valid key was pressed
@@ -2599,10 +2637,10 @@ from actions import (
 ...
 
         ...
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
 -           action = EscapeAction(player)
 +           raise SystemExit()
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
             self.engine.event_handler = HistoryViewer(self.engine)
         ...
 {{</ highlight >}}
@@ -2619,10 +2657,10 @@ from actions import (
 ...
 
         ...
-        elif key == tcod.event.K_ESCAPE:
+        elif key == tcod.event.KeySym.ESCAPE:
             <span class="crossed-out-text">action = EscapeAction(player)</span>
             <span class="new-text">raise SystemExit()</span>
-        elif key == tcod.event.K_v:
+        elif key == tcod.event.KeySym.v:
             self.engine.event_handler = HistoryViewer(self.engine)
         ...</pre>
 {{</ original-tab >}}

--- a/content/tutorials/tcod/v2/part-9.md
+++ b/content/tutorials/tcod/v2/part-9.md
@@ -296,14 +296,14 @@ Open up `input_handlers.py` and add the following contents:
 {{< highlight diff >}}
 ...
 WAIT_KEYS = {
-    tcod.event.K_PERIOD,
-    tcod.event.K_KP_5,
-    tcod.event.K_CLEAR,
+    tcod.event.KeySym.PERIOD,
+    tcod.event.KeySym.KP_5,
+    tcod.event.KeySym.CLEAR,
 }
 
 +CONFIRM_KEYS = {
-+   tcod.event.K_RETURN,
-+   tcod.event.K_KP_ENTER,
++   tcod.event.KeySym.RETURN,
++   tcod.event.KeySym.KP_ENTER,
 +}
 
 ...
@@ -320,23 +320,23 @@ class InventoryDropHandler(InventoryEventHandler):
 +       player = self.engine.player
 +       engine.mouse_location = player.x, player.y
 
-+   def on_render(self, console: tcod.Console) -> None:
++   def on_render(self, console: tcod.console.Console) -> None:
 +       """Highlight the tile under the cursor."""
 +       super().on_render(console)
 +       x, y = self.engine.mouse_location
-+       console.tiles_rgb["bg"][x, y] = color.white
-+       console.tiles_rgb["fg"][x, y] = color.black
++       console.rgb["bg"][x, y] = color.white
++       console.rgb["fg"][x, y] = color.black
 
 +   def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
 +       """Check for key movement or confirmation keys."""
 +       key = event.sym
 +       if key in MOVE_KEYS:
 +           modifier = 1  # Holding modifier keys will speed up key movement.
-+           if event.mod & (tcod.event.KMOD_LSHIFT | tcod.event.KMOD_RSHIFT):
++           if event.mod & (tcod.event.Modifier.LSHIFT | tcod.event.Modifier.RSHIFT):
 +               modifier *= 5
-+           if event.mod & (tcod.event.KMOD_LCTRL | tcod.event.KMOD_RCTRL):
++           if event.mod & (tcod.event.Modifier.LCTRL | tcod.event.Modifier.RCTRL):
 +               modifier *= 10
-+           if event.mod & (tcod.event.KMOD_LALT | tcod.event.KMOD_RALT):
++           if event.mod & (tcod.event.Modifier.LALT | tcod.event.Modifier.RALT):
 +               modifier *= 20
 
 +           x, y = self.engine.mouse_location
@@ -354,9 +354,10 @@ class InventoryDropHandler(InventoryEventHandler):
 
 +   def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
 +       """Left click confirms a selection."""
-+       if self.engine.game_map.in_bounds(*event.tile):
-+           if event.button == 1:
-+               return self.on_index_selected(*event.tile)
++       x, y = int(event.position[0]), int(event.position[1])
++       if self.engine.game_map.in_bounds(x, y):
++           if event.button == tcod.event.MouseButton.LEFT:
++               return self.on_index_selected(x, y)
 +       return super().ev_mousebuttondown(event)
 
 +   def on_index_selected(self, x: int, y: int) -> Optional[Action]:
@@ -379,14 +380,14 @@ class MainGameEventHandler(EventHandler):
 {{< original-tab >}}
 <pre>...
 WAIT_KEYS = {
-    tcod.event.K_PERIOD,
-    tcod.event.K_KP_5,
-    tcod.event.K_CLEAR,
+    tcod.event.KeySym.PERIOD,
+    tcod.event.KeySym.KP_5,
+    tcod.event.KeySym.CLEAR,
 }
 
 <span class="new-text">CONFIRM_KEYS = {
-    tcod.event.K_RETURN,
-    tcod.event.K_KP_ENTER,
+    tcod.event.KeySym.RETURN,
+    tcod.event.KeySym.KP_ENTER,
 }</span>
 
 ...
@@ -403,23 +404,23 @@ class InventoryDropHandler(InventoryEventHandler):
         player = self.engine.player
         engine.mouse_location = player.x, player.y
 
-    def on_render(self, console: tcod.Console) -> None:
+    def on_render(self, console: tcod.console.Console) -> None:
         """Highlight the tile under the cursor."""
         super().on_render(console)
         x, y = self.engine.mouse_location
-        console.tiles_rgb["bg"][x, y] = color.white
-        console.tiles_rgb["fg"][x, y] = color.black
+        console.rgb["bg"][x, y] = color.white
+        console.rgb["fg"][x, y] = color.black
 
     def ev_keydown(self, event: tcod.event.KeyDown) -> Optional[Action]:
         """Check for key movement or confirmation keys."""
         key = event.sym
         if key in MOVE_KEYS:
             modifier = 1  # Holding modifier keys will speed up key movement.
-            if event.mod & (tcod.event.KMOD_LSHIFT | tcod.event.KMOD_RSHIFT):
+            if event.mod & (tcod.event.Modifier.LSHIFT | tcod.event.Modifier.RSHIFT):
                 modifier *= 5
-            if event.mod & (tcod.event.KMOD_LCTRL | tcod.event.KMOD_RCTRL):
+            if event.mod & (tcod.event.Modifier.LCTRL | tcod.event.Modifier.RCTRL):
                 modifier *= 10
-            if event.mod & (tcod.event.KMOD_LALT | tcod.event.KMOD_RALT):
+            if event.mod & (tcod.event.Modifier.LALT | tcod.event.Modifier.RALT):
                 modifier *= 20
 
             x, y = self.engine.mouse_location
@@ -437,9 +438,10 @@ class InventoryDropHandler(InventoryEventHandler):
 
     def ev_mousebuttondown(self, event: tcod.event.MouseButtonDown) -> Optional[Action]:
         """Left click confirms a selection."""
-        if self.engine.game_map.in_bounds(*event.tile):
-            if event.button == 1:
-                return self.on_index_selected(*event.tile)
+        x, y = int(event.position[0]), int(event.position[1])
+        if self.engine.game_map.in_bounds(x, y):
+            if event.button == tcod.event.MouseButton.LEFT:
+                return self.on_index_selected(x, y)
         return super().ev_mousebuttondown(event)
 
     def on_index_selected(self, x: int, y: int) -> Optional[Action]:
@@ -479,11 +481,11 @@ We can utilize `LookHandler` by adding this to `ev_keydown` in `MainGameEventHan
 {{< diff-tab >}}
 {{< highlight diff >}}
         ...
-        elif key == tcod.event.K_i:
+        elif key == tcod.event.KeySym.i:
             self.engine.event_handler = InventoryActivateHandler(self.engine)
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
             self.engine.event_handler = InventoryDropHandler(self.engine)
-+       elif key == tcod.event.K_SLASH:
++       elif key == tcod.event.KeySym.SLASH:
 +           self.engine.event_handler = LookHandler(self.engine)
 
         # No valid key was pressed
@@ -492,11 +494,11 @@ We can utilize `LookHandler` by adding this to `ev_keydown` in `MainGameEventHan
 {{</ diff-tab >}}
 {{< original-tab >}}
 <pre>        ...
-        elif key == tcod.event.K_i:
+        elif key == tcod.event.KeySym.i:
             self.engine.event_handler = InventoryActivateHandler(self.engine)
-        elif key == tcod.event.K_d:
+        elif key == tcod.event.KeySym.d:
             self.engine.event_handler = InventoryDropHandler(self.engine)
-        <span class="new-text">elif key == tcod.event.K_SLASH:
+        <span class="new-text">elif key == tcod.event.KeySym.SLASH:
             self.engine.event_handler = LookHandler(self.engine)</span>
 
         # No valid key was pressed


### PR DESCRIPTION
## Summary

This PR updates the v2 tutorial to work with **tcod 21.2.0** and **NumPy 2.x**, bringing them in line with the current library API. 27 files changed across `content/tutorials/tcod/2019/` (parts 0–13, except part-3) and `content/tutorials/tcod/v2/` (parts 0–13).

The changes are intentionally **minimal and surgical**: only API-level replacements, no rewriting of game logic or tutorial structure.

---

## Changes

The v2 series was closer to the modern API but still had some outdated calls and deprecated patterns:

- `tcod.context.new_terminal(...)` → `tcod.context.new(columns=..., rows=...)` (deprecated name)
- `tcod.Console(...)` → `tcod.console.Console(...)` (canonical path)
- `.print(string=...)` → `.print(text=...)` (parameter renamed in tcod 11.x)
- `root_console` → `console` (consistent rename throughout)
- `int(x / 2)` → `x // 2` (idiomatic integer division)
- `np.bool` → `np.bool_` — **important fix**: `np.bool` was removed in NumPy 1.24; this would crash with NumPy 2.x
- `if event.type == "QUIT":` → `match event: case tcod.event.Quit():` (modern event handling)
- `Path(__file__).with_name(...)` for asset paths — more robust than bare strings
- `from __future__ import annotations` added consistently
- Type hints modernized (`Optional[X]` → `X | None`)
- Dependency versions updated: `tcod>=21.2,<22`, `numpy>=2.4,<3`
- Python minimum updated to **3.11**; reviewed with Python 3.14.4, tcod 21.2.0, numpy 2.4.2 (April 2026)
- Version notes in part-3 and other parts updated to reflect current library versions

---

## Why these tutorials are still worth maintaining

I'd like to make a case for keeping both series alive and up to date.

**These are still among the best beginner roguelike tutorials available.** The structure — 14 parts, building a complete dungeon crawler from scratch, covering everything from a moving `@` to saving/loading, inventory, spells, equipment and procedural generation — is genuinely hard to find elsewhere at this level of quality and completeness. The RogueBasin lineage gives them credibility, and the Python + tcod combination is still the most accessible entry point for someone who wants to write a roguelike without wrestling with C++ or a full game engine.

**The 2019 series and v2 serve different audiences, and both have real value:**

The **2019 series** is the better tutorial for a complete beginner. Part 1 is 40 lines and you have a moving `@` on screen. The patterns it teaches — `handle_keys` returning dicts, `GameStates` enum, step-by-step render functions — are "visible" complexity: the code looks like what it does. The fact that those patterns don't scale well is actually pedagogically useful: you *experience* the pain of an ever-growing `if/elif` in `engine.py` and *discover* why you'd want to refactor. That motivated discovery is worth more than copying a clean `Action + EventHandler` pattern without knowing what problem it solves.

The **v2 series** is the better tutorial if you already have some OOP experience and want to end up with a codebase you can actually extend. The Action-based input, interchangeable EventHandlers as a state machine, NumPy for the map and FOV, and `pickle+lzma` serialization of the whole Engine are all genuinely good architectural decisions that hold up as the codebase grows. The type hints and `from __future__ import annotations` also teach habits that matter in real Python projects.

In short: the 2019 series teaches you *how to build a roguelike*; the v2 teaches you *how to build one well*. Both are useful. Keeping them up to date means both remain usable entry points rather than historical artifacts that confuse beginners with deprecated API calls and `AttributeError: module 'numpy' has no attribute 'bool'`.